### PR TITLE
Persist scraped data in Git and optimize incremental processing

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -16,9 +16,6 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
-        with:
-          # Crucial: prevents duplicate Authorization header errors
-          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -34,14 +31,10 @@ jobs:
           LOCATIONIQ_API_KEY: ${{ secrets.LOCATIONIQ_API_KEY }}
         run: python3 pipeline.py
 
-      - name: Create Pull Request
-        # Upgraded from v4 to v6 to fix the "undefined reading number" error
-        uses: peter-evans/create-pull-request@v6
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: Automated data scrape
-          title: 'Automated data scrape'
-          body: |
-            Automated data scrape
-          branch: 'automated-scrape'
-          delete-branch: true
+      - name: Commit and push changes
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git add wildflowers_data.json geocache.csv
+          git commit -m "Automated data scrape [skip ci]" || echo "No changes to commit"
+          git push

--- a/pipeline.py
+++ b/pipeline.py
@@ -265,8 +265,12 @@ def process_tiuli_files(existing_data, geocache, session, html_dir='tiuli_scrape
     new_reports = []
     existing_reports_keys = set()
     for report in existing_data:
-        if 'source_file' in report and 'original_text' in report:
-            existing_reports_keys.add((report['source_file'], report['original_text']))
+        if 'source_file' in report:
+            ot = report.get('original_text')
+            if not ot and report.get('description') and len(report['description']) > 0:
+                ot = report['description'][0]
+            if ot:
+                existing_reports_keys.add((report['source_file'], ot))
 
 
     for filename in os.listdir(html_dir):
@@ -278,8 +282,17 @@ def process_tiuli_files(existing_data, geocache, session, html_dir='tiuli_scrape
                     soup = BeautifulSoup(html_content, 'html.parser')
                     articles = soup.find_all('article', class_='shadow-card')
                     for article in articles:
-                        original_text_element = article.find('div', class_='mt-1', recursive=False)
-                        original_text = original_text_element.get_text(strip=True) if original_text_element else ""
+                        # Extract report details
+                        report_details = article.find('div', class_='report-details')
+                        original_text = ""
+                        if report_details:
+                            original_text_element = report_details.find('div', class_='mt-1')
+                            if original_text_element:
+                                original_text = original_text_element.get_text(strip=True)
+
+                        if not original_text:
+                            original_text_element = article.find('div', class_='mt-1', recursive=False)
+                            original_text = original_text_element.get_text(strip=True) if original_text_element else ""
 
                         if (filepath, original_text) in existing_reports_keys:
                             continue
@@ -298,15 +311,6 @@ def process_tiuli_files(existing_data, geocache, session, html_dir='tiuli_scrape
                         report['date'] = date
                         report['observer'] = observer
 
-
-                        # Extract report details
-                        report_details = article.find('div', class_='report-details')
-                        original_text = ""
-                        if report_details:
-                            original_text_element = report_details.find('div', class_='mt-1')
-                            if original_text_element:
-                                original_text = original_text_element.get_text(strip=True)
-
                         flower_name_element = report_details.find('h2', class_='m-0 font-bold text-lg lg:text-2xl').find('a')
                         flower_name = flower_name_element.get_text(strip=True) if flower_name_element else None
                         location_element = report_details.find('span', string=re.compile(r'מיקום:.*'))
@@ -316,6 +320,7 @@ def process_tiuli_files(existing_data, geocache, session, html_dir='tiuli_scrape
                         report['description'] = [original_text]
                         report['locations'] = [location]
                         report['flowers'] = [flower_name]
+                        report['original_text'] = original_text
 
                         # Extract Waze and map button data, and extract coordinates if available.
                         geocoded_locations = {}

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -58,6 +58,24 @@ class TestPipeline(unittest.TestCase):
         self.assertEqual(report['flowers'], ['Test Flower'])
         self.assertEqual(report['observer'], 'Test Observer')
         self.assertEqual(report['date'], '01/01/2024')
+        self.assertEqual(report['original_text'], 'Test report content.')
+
+    @patch('pipeline.get_coordinates')
+    def test_process_tiuli_files_skips_existing(self, mock_get_coordinates):
+        # Mock the get_coordinates function to return empty coordinates
+        mock_get_coordinates.return_value = []
+
+        # Create existing data with the same report
+        existing_data = [{
+            'source_file': os.path.join(self.test_dir, 'test.html'),
+            'original_text': 'Test report content.'
+        }]
+
+        # Run the process_tiuli_files function
+        new_reports = process_tiuli_files(existing_data, self.mock_geocache, self.mock_session, html_dir=self.test_dir)
+
+        # Check that the function returns 0 new reports
+        self.assertEqual(len(new_reports), 0)
 
     def test_save_data(self):
         # Create some test data


### PR DESCRIPTION
The changes ensure that scraped data is persisted in the repository, allowing subsequent runs of the data pipeline to skip already processed reports and geocoding. This improves efficiency and reduces API costs.

---
*PR created automatically by Jules for task [7563437526489490000](https://jules.google.com/task/7563437526489490000) started by @baobabprince*