### PR TITLE
Fix duplicate scraping and append loop in data pipeline

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -265,8 +265,16 @@ def process_tiuli_files(existing_data, geocache, session, html_dir='tiuli_scrape
     new_reports = []
     existing_reports_keys = set()
     for report in existing_data:
-        if 'source_file' in report and 'original_text' in report:
-            existing_reports_keys.add((report['source_file'], report['original_text']))
+        if 'source_file' in report:
+            desc = report.get('description', [])
+            original_text = desc[0] if isinstance(desc, list) and len(desc) > 0 else ""
+            existing_reports_keys.add((
+                report['source_file'],
+                report.get('observer') or '',
+                report.get('date') or '',
+                report.get('title') or '',
+                original_text
+            ))
 
 
     for filename in os.listdir(html_dir):
@@ -278,38 +286,40 @@ def process_tiuli_files(existing_data, geocache, session, html_dir='tiuli_scrape
                     soup = BeautifulSoup(html_content, 'html.parser')
                     articles = soup.find_all('article', class_='shadow-card')
                     for article in articles:
-                        original_text_element = article.find('div', class_='mt-1', recursive=False)
-                        original_text = original_text_element.get_text(strip=True) if original_text_element else ""
-
-                        if (filepath, original_text) in existing_reports_keys:
-                            continue
-
-                        # ... (rest of the extraction logic from tiuli_parse.py)
-                        report = {}
-
                         # Extract user details
-                        user_details = article.find('div', class_='user-details')
-                        observer_element = user_details.find('span', class_='text-grey-900')
+                        user_details = article.find('div', class_='user-details') if article else None
+                        observer_element = user_details.find('span', class_='text-grey-900') if user_details else None
                         observer = observer_element.get_text(strip=True) if observer_element else None
 
-                        date_element = user_details.find('span', class_='text-grey-700')
+                        date_element = user_details.find('span', class_='text-grey-700') if user_details else None
                         date = date_element.get_text(strip=True) if date_element else None
 
-                        report['date'] = date
-                        report['observer'] = observer
-
-
                         # Extract report details
-                        report_details = article.find('div', class_='report-details')
+                        report_details = article.find('div', class_='report-details') if article else None
                         original_text = ""
                         if report_details:
                             original_text_element = report_details.find('div', class_='mt-1')
                             if original_text_element:
                                 original_text = original_text_element.get_text(strip=True)
 
-                        flower_name_element = report_details.find('h2', class_='m-0 font-bold text-lg lg:text-2xl').find('a')
-                        flower_name = flower_name_element.get_text(strip=True) if flower_name_element else None
-                        location_element = report_details.find('span', string=re.compile(r'מיקום:.*'))
+                        flower_name = None
+                        if report_details:
+                            h2_element = report_details.find('h2', class_='m-0 font-bold text-lg lg:text-2xl')
+                            if h2_element:
+                                flower_name_element = h2_element.find('a')
+                                if flower_name_element:
+                                    flower_name = flower_name_element.get_text(strip=True)
+
+                        # Check if report already exists in existing_data
+                        key = (filepath, observer or "", date or "", flower_name or "", original_text or "")
+                        if key in existing_reports_keys:
+                            continue
+
+                        report = {}
+                        report['date'] = date
+                        report['observer'] = observer
+
+                        location_element = report_details.find('span', string=re.compile(r'מיקום:.*')) if report_details else None
                         location = location_element.get_text(strip=True).replace("מיקום: ", "") if location_element else None
 
                         report['title'] = flower_name

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -59,6 +59,25 @@ class TestPipeline(unittest.TestCase):
         self.assertEqual(report['observer'], 'Test Observer')
         self.assertEqual(report['date'], '01/01/2024')
 
+    @patch('pipeline.get_coordinates')
+    def test_process_tiuli_files_duplicate_filtering(self, mock_get_coordinates):
+        mock_get_coordinates.return_value = []
+
+        # Mock existing_data that should match our dummy HTML file
+        existing_data = [{
+            'source_file': os.path.join(self.test_dir, 'test.html'),
+            'observer': 'Test Observer',
+            'date': '01/01/2024',
+            'title': 'Test Flower',
+            'description': ['Test report content.']
+        }]
+
+        # Run the process_tiuli_files function with existing_data
+        new_reports = process_tiuli_files(existing_data, self.mock_geocache, self.mock_session, html_dir=self.test_dir)
+
+        # Since it is a duplicate, it should be filtered out
+        self.assertEqual(len(new_reports), 0)
+
     def test_save_data(self):
         # Create some test data
         test_data = [{'title': 'Test Flower', 'description': ['Test report content.']}]

--- a/wildflowers_data.json
+++ b/wildflowers_data.json
@@ -6531,23 +6531,6 @@
     "source_file": "tiuli_scraped_reports/page_168_report_1_class.html"
   },
   {
-    "date": "07/12/2008",
-    "observer": "המטייל האנונימי",
-    "title": "רקפת מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "קבעת הרקפות ליד גלעד"
-    ],
-    "flowers": [
-      "רקפת מצויה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_168_report_1_class.html"
-  },
-  {
     "date": "02/12/2008",
     "observer": "המטייל האנונימי",
     "title": "חלמונית גדולה",
@@ -6828,23 +6811,6 @@
     ],
     "locations": [
       "פארק הסלעים כסרא"
-    ],
-    "flowers": [
-      "כרכום חורפי"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_168_report_1_class.html"
-  },
-  {
-    "date": "22/11/2008",
-    "observer": "המטייל האנונימי",
-    "title": "כרכום חורפי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער צלפון"
     ],
     "flowers": [
       "כרכום חורפי"
@@ -7309,23 +7275,6 @@
   {
     "date": "31/01/2014",
     "observer": "עידו מגן",
-    "title": "שקד מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "כביש 395"
-    ],
-    "flowers": [
-      "שקד מצוי"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_98_report_1_class.html"
-  },
-  {
-    "date": "31/01/2014",
-    "observer": "עידו מגן",
     "title": "כלנית מצויה",
     "description": [
       ""
@@ -7666,23 +7615,6 @@
   {
     "date": "25/01/2014",
     "observer": "אלחי47",
-    "title": "יקינתון מזרחי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הארבל"
-    ],
-    "flowers": [
-      "יקינתון מזרחי"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_98_report_1_class.html"
-  },
-  {
-    "date": "25/01/2014",
-    "observer": "אלחי47",
     "title": "שיכרון זהוב",
     "description": [
       ""
@@ -7726,40 +7658,6 @@
     ],
     "flowers": [
       "כלנית מצויה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_98_report_1_class.html"
-  },
-  {
-    "date": "25/01/2014",
-    "observer": "אלחי47",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "ארבל"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_98_report_1_class.html"
-  },
-  {
-    "date": "25/01/2014",
-    "observer": "אלחי47",
-    "title": "עירית גדולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "ארבל וקרני-חיטין"
-    ],
-    "flowers": [
-      "עירית גדולה"
     ],
     "geocoded_locations": {},
     "coordinates": [],
@@ -8889,28 +8787,6 @@
     "source_file": "tiuli_scraped_reports/page_42_report_1_class.html"
   },
   {
-    "date": "16/01/2021",
-    "observer": "Iddo_3270859",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שמורת שער פולג"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "שמורת שער פולג": {
-        "latitude": 32.256896,
-        "longitude": 34.84253229999999
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_42_report_1_class.html"
-  },
-  {
     "date": "14/01/2021",
     "observer": "moshlesh",
     "title": "ציפורנית מצרית",
@@ -9154,28 +9030,6 @@
   },
   {
     "date": "07/01/2021",
-    "observer": "Iddo_3270859",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הגן הלאומי גבעות הכורכר נס ציונה, דרך גבעות הכורכר, נס ציונה"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "הגן הלאומי גבעות הכורכר נס ציונה, דרך גבעות הכורכר, נס ציונה": {
-        "latitude": 31.9329054,
-        "longitude": 34.7862453
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_42_report_1_class.html"
-  },
-  {
-    "date": "07/01/2021",
     "observer": "הסיה",
     "title": "זהבית השלוחות",
     "description": [
@@ -9345,28 +9199,6 @@
       "דרך החורש, שוהם": {
         "latitude": 32.0082197,
         "longitude": 34.9615581
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_42_report_1_class.html"
-  },
-  {
-    "date": "01/01/2021",
-    "observer": "Iddo_3270859",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "תל חדיד"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "תל חדיד": {
-        "latitude": 31.963534,
-        "longitude": 34.95203
       }
     },
     "coordinates": [],
@@ -9648,28 +9480,6 @@
     ],
     "flowers": [
       "נרקיס מצוי"
-    ],
-    "geocoded_locations": {
-      "אלוני אבא": {
-        "latitude": 32.730945,
-        "longitude": 35.172028
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_42_report_1_class.html"
-  },
-  {
-    "date": "26/12/2020",
-    "observer": "עידו מגן",
-    "title": "כרכום חורפי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "אלוני אבא"
-    ],
-    "flowers": [
-      "כרכום חורפי"
     ],
     "geocoded_locations": {
       "אלוני אבא": {
@@ -10717,50 +10527,6 @@
   {
     "date": "11/03/2017",
     "observer": "עידו מגן",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "גבעת התנ\"ך ליד מתחם התחנה בירושלים"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "גבעת התנ\"ך ליד מתחם התחנה בירושלים": {
-        "latitude": 31.7681,
-        "longitude": 35.2276
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_63_report_1_class.html"
-  },
-  {
-    "date": "11/03/2017",
-    "observer": "עידו מגן",
-    "title": "צהרון מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "גבעת התנ\"ך ליד מתחם התחנה בירושלים"
-    ],
-    "flowers": [
-      "צהרון מצוי"
-    ],
-    "geocoded_locations": {
-      "גבעת התנ\"ך ליד מתחם התחנה בירושלים": {
-        "latitude": 31.7681,
-        "longitude": 35.2276
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_63_report_1_class.html"
-  },
-  {
-    "date": "11/03/2017",
-    "observer": "עידו מגן",
     "title": "כליל החורש",
     "description": [
       ""
@@ -10868,23 +10634,6 @@
   {
     "date": "22/02/2008",
     "observer": "המטייל האנונימי",
-    "title": "רקפת מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "כביש מס' 2 בקטע קיסריה - זכרון יעקב"
-    ],
-    "flowers": [
-      "רקפת מצויה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_176_report_1_class.html"
-  },
-  {
-    "date": "22/02/2008",
-    "observer": "המטייל האנונימי",
     "title": "עירית גדולה",
     "description": [
       ""
@@ -10911,23 +10660,6 @@
     ],
     "flowers": [
       "תורמוס ההרים"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_176_report_1_class.html"
-  },
-  {
-    "date": "22/02/2008",
-    "observer": "המטייל האנונימי",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "כביש 70 (זכרון-יקנעם)"
-    ],
-    "flowers": [
-      "כלנית מצויה"
     ],
     "geocoded_locations": {},
     "coordinates": [],
@@ -11027,23 +10759,6 @@
     ],
     "locations": [
       "יער שוהם, יער אלעד, גבעת תיתורה במודיעין"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_176_report_1_class.html"
-  },
-  {
-    "date": "16/02/2008",
-    "observer": "המטייל האנונימי",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "עין ורד ליד תל גזר"
     ],
     "flowers": [
       "כלנית מצויה"
@@ -11463,23 +11178,6 @@
   {
     "date": "09/02/2008",
     "observer": "המטייל האנונימי",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "התחלת כביש בית אורן"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_176_report_1_class.html"
-  },
-  {
-    "date": "09/02/2008",
-    "observer": "המטייל האנונימי",
     "title": "צהרון מצוי",
     "description": [
       ""
@@ -11665,28 +11363,6 @@
   {
     "date": "10/12/2023",
     "observer": "אלחי47",
-    "title": "חלמונית גדולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שומרון גוש עציון כרמי צור"
-    ],
-    "flowers": [
-      "חלמונית גדולה"
-    ],
-    "geocoded_locations": {
-      "שומרון גוש עציון כרמי צור": {
-        "latitude": 31.605,
-        "longitude": 35.1
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_9_report_1_class.html"
-  },
-  {
-    "date": "10/12/2023",
-    "observer": "אלחי47",
     "title": "חד-שפה מזרחי",
     "description": [
       ""
@@ -11701,28 +11377,6 @@
       "שיח עם פרחים מרובים נראה בשדה מתחת לכרמי צור ב-4.12.23": {
         "latitude": 31.55,
         "longitude": 35.099
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_9_report_1_class.html"
-  },
-  {
-    "date": "10/12/2023",
-    "observer": "אלחי47",
-    "title": "כרכום נאה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שומרון  גוש עציון מול כרמי צור"
-    ],
-    "flowers": [
-      "כרכום נאה"
-    ],
-    "geocoded_locations": {
-      "שומרון  גוש עציון מול כרמי צור": {
-        "latitude": 31.593,
-        "longitude": 35.19
       }
     },
     "coordinates": [],
@@ -11905,28 +11559,6 @@
     "source_file": "tiuli_scraped_reports/page_9_report_1_class.html"
   },
   {
-    "date": "09/12/2023",
-    "observer": "אלחי47",
-    "title": "אצבוע אירופי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "עמק המצלבה, ירושלים"
-    ],
-    "flowers": [
-      "אצבוע אירופי"
-    ],
-    "geocoded_locations": {
-      "עמק המצלבה, ירושלים": {
-        "latitude": 31.774,
-        "longitude": 35.208
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_9_report_1_class.html"
-  },
-  {
     "date": "08/12/2023",
     "observer": "Iddo_3270859",
     "title": "רקפת מצויה",
@@ -12075,28 +11707,6 @@
       "כוש עציון-אספר": {
         "latitude": 31.596,
         "longitude": 35.192
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_9_report_1_class.html"
-  },
-  {
-    "date": "08/12/2023",
-    "observer": "אלחי47",
-    "title": "כרכום גיירדו",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "צומת גוש עציון"
-    ],
-    "flowers": [
-      "כרכום גיירדו"
-    ],
-    "geocoded_locations": {
-      "צומת גוש עציון": {
-        "latitude": 31.634,
-        "longitude": 35.127
       }
     },
     "coordinates": [],
@@ -12302,28 +11912,6 @@
   },
   {
     "date": "24/11/2023",
-    "observer": "Iddo_3270859",
-    "title": "סתוונית היורה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חורבת עקד"
-    ],
-    "flowers": [
-      "סתוונית היורה"
-    ],
-    "geocoded_locations": {
-      "חורבת עקד": {
-        "latitude": 31.8363074,
-        "longitude": 35.00873169999999
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_9_report_1_class.html"
-  },
-  {
-    "date": "24/11/2023",
     "observer": "מ.פ 1967",
     "title": "כרכום חורפי",
     "description": [
@@ -12521,50 +12109,6 @@
     "source_file": "tiuli_scraped_reports/page_9_report_1_class.html"
   },
   {
-    "date": "02/10/2023",
-    "observer": "מ.פ 1967",
-    "title": "חצב מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער צרעה חניון שאול"
-    ],
-    "flowers": [
-      "חצב מצוי"
-    ],
-    "geocoded_locations": {
-      "יער צרעה חניון שאול": {
-        "latitude": 31.78450872135206,
-        "longitude": 34.98171329498291
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_9_report_1_class.html"
-  },
-  {
-    "date": "26/09/2023",
-    "observer": "אביטל טביב",
-    "title": "חצב מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "גן לאומי תל אפק, תל אפק"
-    ],
-    "flowers": [
-      "חצב מצוי"
-    ],
-    "geocoded_locations": {
-      "גן לאומי תל אפק, תל אפק": {
-        "latitude": 32.10530919999999,
-        "longitude": 34.930512
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_9_report_1_class.html"
-  },
-  {
     "date": "26/09/2023",
     "observer": "אביטל טביב",
     "title": "חצב מצוי",
@@ -12603,28 +12147,6 @@
       "צרעה": {
         "latitude": 31.770978178369482,
         "longitude": 34.96211378761879
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_9_report_1_class.html"
-  },
-  {
-    "date": "24/09/2023",
-    "observer": "Iddo_3270859",
-    "title": "חצב מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מחלף נשרים"
-    ],
-    "flowers": [
-      "חצב מצוי"
-    ],
-    "geocoded_locations": {
-      "מחלף נשרים": {
-        "latitude": 31.9089584,
-        "longitude": 34.8944813
       }
     },
     "coordinates": [],
@@ -12678,23 +12200,6 @@
     ],
     "locations": [
       "יער להב"
-    ],
-    "flowers": [
-      "חלמונית גדולה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_141_report_1_class.html"
-  },
-  {
-    "date": "23/11/2010",
-    "observer": "ירוחם1",
-    "title": "חלמונית גדולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער יתיר"
     ],
     "flowers": [
       "חלמונית גדולה"
@@ -13000,46 +12505,12 @@
   {
     "date": "09/10/2010",
     "observer": "המטייל האנונימי",
-    "title": "חצב מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל אבליים"
-    ],
-    "flowers": [
-      "חצב מצוי"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_141_report_1_class.html"
-  },
-  {
-    "date": "09/10/2010",
-    "observer": "המטייל האנונימי",
     "title": "סתוונית התשבץ",
     "description": [
       ""
     ],
     "locations": [
       "רכס בשנית"
-    ],
-    "flowers": [
-      "סתוונית התשבץ"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_141_report_1_class.html"
-  },
-  {
-    "date": "09/10/2010",
-    "observer": "המטייל האנונימי",
-    "title": "סתוונית התשבץ",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער עין-זיוון"
     ],
     "flowers": [
       "סתוונית התשבץ"
@@ -13989,23 +13460,6 @@
     "source_file": "tiuli_scraped_reports/page_136_report_1_class.html"
   },
   {
-    "date": "02/04/2011",
-    "observer": "אלחי47",
-    "title": "סחלב נקוד",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל צניר (חניתה) צד ימין של הדרך"
-    ],
-    "flowers": [
-      "סחלב נקוד"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_136_report_1_class.html"
-  },
-  {
     "date": "01/04/2011",
     "observer": "shfr",
     "title": "תורמוס ההרים",
@@ -14627,28 +14081,6 @@
   {
     "date": "17/04/2010",
     "observer": "גדי פולק",
-    "title": "שמשון הדור",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "בורות לוץ"
-    ],
-    "flowers": [
-      "שמשון הדור"
-    ],
-    "geocoded_locations": {
-      "בורות לוץ": {
-        "latitude": 30.5144,
-        "longitude": 34.6099
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_143_report_1_class.html"
-  },
-  {
-    "date": "17/04/2010",
-    "observer": "גדי פולק",
     "title": "הרדופנין הציצית",
     "description": [
       ""
@@ -14693,28 +14125,6 @@
   {
     "date": "17/04/2010",
     "observer": "גדי פולק",
-    "title": "צבעוני ההרים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "בורות לוץ"
-    ],
-    "flowers": [
-      "צבעוני ההרים"
-    ],
-    "geocoded_locations": {
-      "בורות לוץ": {
-        "latitude": 30.5144,
-        "longitude": 34.6099
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_143_report_1_class.html"
-  },
-  {
-    "date": "17/04/2010",
-    "observer": "גדי פולק",
     "title": "צבעוני ססגוני",
     "description": [
       ""
@@ -14746,28 +14156,6 @@
     ],
     "flowers": [
       "מנתור המדבר"
-    ],
-    "geocoded_locations": {
-      "בורות לוץ": {
-        "latitude": 30.5144,
-        "longitude": 34.6099
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_143_report_1_class.html"
-  },
-  {
-    "date": "17/04/2010",
-    "observer": "גדי פולק",
-    "title": "שבר לבן",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "בורות לוץ"
-    ],
-    "flowers": [
-      "שבר לבן"
     ],
     "geocoded_locations": {
       "בורות לוץ": {
@@ -15524,28 +14912,6 @@
   {
     "date": "18/04/2024",
     "observer": "אביטל טביב",
-    "title": "זקן-סב מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער לנדאו יער השומרים"
-    ],
-    "flowers": [
-      "זקן-סב מצוי"
-    ],
-    "geocoded_locations": {
-      "יער לנדאו יער השומרים": {
-        "latitude": 32.7087307,
-        "longitude": 35.1344415
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_3_report_1_class.html"
-  },
-  {
-    "date": "18/04/2024",
-    "observer": "אביטל טביב",
     "title": "פרג אגסי",
     "description": [
       ""
@@ -15722,50 +15088,6 @@
   {
     "date": "13/04/2024",
     "observer": "Iddo_3270859",
-    "title": "חוטמית זיפנית",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "דרך 1, ירושלים"
-    ],
-    "flowers": [
-      "חוטמית זיפנית"
-    ],
-    "geocoded_locations": {
-      "דרך 1, ירושלים": {
-        "latitude": 31.796732,
-        "longitude": 35.1777742
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_3_report_1_class.html"
-  },
-  {
-    "date": "13/04/2024",
-    "observer": "Iddo_3270859",
-    "title": "חוטמית זיפנית",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "כביש 375/מטע, מטע"
-    ],
-    "flowers": [
-      "חוטמית זיפנית"
-    ],
-    "geocoded_locations": {
-      "כביש 375/מטע, מטע": {
-        "latitude": 31.71324,
-        "longitude": 35.06322900000001
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_3_report_1_class.html"
-  },
-  {
-    "date": "13/04/2024",
-    "observer": "Iddo_3270859",
     "title": "בן-סחלב צריפי",
     "description": [
       ""
@@ -15920,28 +15242,6 @@
   {
     "date": "06/04/2024",
     "observer": "Iddo_3270859",
-    "title": "סחלב שלוש השיניים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הר איתן 788"
-    ],
-    "flowers": [
-      "סחלב שלוש השיניים"
-    ],
-    "geocoded_locations": {
-      "הר איתן 788": {
-        "latitude": 31.769827,
-        "longitude": 35.11283599999999
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_3_report_1_class.html"
-  },
-  {
-    "date": "06/04/2024",
-    "observer": "Iddo_3270859",
     "title": "סחלב הגליל",
     "description": [
       ""
@@ -15978,28 +15278,6 @@
       "משמר דוד": {
         "latitude": 31.813985668106614,
         "longitude": 34.89646857208097
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_3_report_1_class.html"
-  },
-  {
-    "date": "06/04/2024",
-    "observer": "Iddo_3270859",
-    "title": "נורית אסיה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הר איתן 788"
-    ],
-    "flowers": [
-      "נורית אסיה"
-    ],
-    "geocoded_locations": {
-      "הר איתן 788": {
-        "latitude": 31.769827,
-        "longitude": 35.11283599999999
       }
     },
     "coordinates": [],
@@ -16206,28 +15484,6 @@
   {
     "date": "30/03/2024",
     "observer": "Iddo_3270859",
-    "title": "נורית אסיה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שביל המטוס סובב איתנים, איתנים"
-    ],
-    "flowers": [
-      "נורית אסיה"
-    ],
-    "geocoded_locations": {
-      "שביל המטוס סובב איתנים, איתנים": {
-        "latitude": 31.778466,
-        "longitude": 35.0950645
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_3_report_1_class.html"
-  },
-  {
-    "date": "30/03/2024",
-    "observer": "Iddo_3270859",
     "title": "סחלב שלוש השיניים",
     "description": [
       ""
@@ -16242,28 +15498,6 @@
       "גבעת יערים": {
         "latitude": 31.786089,
         "longitude": 35.09277
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_3_report_1_class.html"
-  },
-  {
-    "date": "30/03/2024",
-    "observer": "Iddo_3270859",
-    "title": "סחלב שלוש השיניים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שביל המטוס סובב איתנים, איתנים"
-    ],
-    "flowers": [
-      "סחלב שלוש השיניים"
-    ],
-    "geocoded_locations": {
-      "שביל המטוס סובב איתנים, איתנים": {
-        "latitude": 31.778466,
-        "longitude": 35.0950645
       }
     },
     "coordinates": [],
@@ -16447,28 +15681,6 @@
   },
   {
     "date": "28/02/2022",
-    "observer": "פצו טיולי",
-    "title": "סחלב פרפרני",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שמורת טבע חוף הבונים, הבונים"
-    ],
-    "flowers": [
-      "סחלב פרפרני"
-    ],
-    "geocoded_locations": {
-      "שמורת טבע חוף הבונים, הבונים": {
-        "latitude": 32.641859,
-        "longitude": 34.92424699999999
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_30_report_1_class.html"
-  },
-  {
-    "date": "28/02/2022",
     "observer": "Iddo_3270859",
     "title": "שקד מצוי",
     "description": [
@@ -16492,28 +15704,6 @@
   {
     "date": "28/02/2022",
     "observer": "Iddo_3270859",
-    "title": "שקד מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל חלילים, מבשרת ציון"
-    ],
-    "flowers": [
-      "שקד מצוי"
-    ],
-    "geocoded_locations": {
-      "נחל חלילים, מבשרת ציון": {
-        "latitude": 31.8061249,
-        "longitude": 35.1575032
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_30_report_1_class.html"
-  },
-  {
-    "date": "28/02/2022",
-    "observer": "Iddo_3270859",
     "title": "כלנית מצויה",
     "description": [
       ""
@@ -16528,50 +15718,6 @@
       "אנדרטת מגילת האש": {
         "latitude": 31.77242820000001,
         "longitude": 35.0442781
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_30_report_1_class.html"
-  },
-  {
-    "date": "28/02/2022",
-    "observer": "Iddo_3270859",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל חלילים, מבשרת ציון"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "נחל חלילים, מבשרת ציון": {
-        "latitude": 31.8061249,
-        "longitude": 35.1575032
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_30_report_1_class.html"
-  },
-  {
-    "date": "28/02/2022",
-    "observer": "Iddo_3270859",
-    "title": "שקד מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "לטרון, לטרון"
-    ],
-    "flowers": [
-      "שקד מצוי"
-    ],
-    "geocoded_locations": {
-      "לטרון, לטרון": {
-        "latitude": 31.836891,
-        "longitude": 34.977195
       }
     },
     "coordinates": [],
@@ -16706,23 +15852,6 @@
         "longitude": 35.374
       }
     },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_30_report_1_class.html"
-  },
-  {
-    "date": "28/02/2022",
-    "observer": "אלחי47",
-    "title": "יקינתון מזרחי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הר תורען, בועיינה-נוג'ידאת"
-    ],
-    "flowers": [
-      "יקינתון מזרחי"
-    ],
-    "geocoded_locations": {},
     "coordinates": [],
     "source_file": "tiuli_scraped_reports/page_30_report_1_class.html"
   },
@@ -17315,28 +16444,6 @@
       "כפר יהושוע": {
         "latitude": 32.682,
         "longitude": 35.126
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_30_report_1_class.html"
-  },
-  {
-    "date": "23/02/2022",
-    "observer": "אלחי47",
-    "title": "אירוס הביצות",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "כפר יהושע"
-    ],
-    "flowers": [
-      "אירוס הביצות"
-    ],
-    "geocoded_locations": {
-      "כפר יהושע": {
-        "latitude": 32.679,
-        "longitude": 35.134
       }
     },
     "coordinates": [],
@@ -19000,28 +18107,6 @@
   {
     "date": "12/03/2020",
     "observer": "אלחי47",
-    "title": "סחלב הגליל",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חיפה גבעת העיזים."
-    ],
-    "flowers": [
-      "סחלב הגליל"
-    ],
-    "geocoded_locations": {
-      "חיפה גבעת העיזים.": {
-        "latitude": 742044.0,
-        "longitude": 199144.0
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_49_report_1_class.html"
-  },
-  {
-    "date": "12/03/2020",
-    "observer": "אלחי47",
     "title": "דבורנית נאה",
     "description": [
       ""
@@ -19218,28 +18303,6 @@
     "source_file": "tiuli_scraped_reports/page_49_report_1_class.html"
   },
   {
-    "date": "12/03/2020",
-    "observer": "אלחי47",
-    "title": "מרווה דגולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שמורת עיינות פצאל"
-    ],
-    "flowers": [
-      "מרווה דגולה"
-    ],
-    "geocoded_locations": {
-      "שמורת עיינות פצאל": {
-        "latitude": 664290.0,
-        "longitude": 236179.0
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_49_report_1_class.html"
-  },
-  {
     "date": "11/03/2020",
     "observer": "מרבילה",
     "title": "אירוס הארגמן",
@@ -19350,28 +18413,6 @@
     "source_file": "tiuli_scraped_reports/page_49_report_1_class.html"
   },
   {
-    "date": "10/03/2020",
-    "observer": "shimonia",
-    "title": "אירוס ירוחם",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שמורת ירוחם"
-    ],
-    "flowers": [
-      "אירוס ירוחם"
-    ],
-    "geocoded_locations": {
-      "שמורת ירוחם": {
-        "latitude": 32.24056248251814,
-        "longitude": 35.13170842794512
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_49_report_1_class.html"
-  },
-  {
     "date": "09/03/2020",
     "observer": "אלחי47",
     "title": "דבורנית דינסמור",
@@ -19408,28 +18449,6 @@
     ],
     "geocoded_locations": {
       "עינות פצאל שומרון": {
-        "latitude": 664897.0,
-        "longitude": 236037.0
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_49_report_1_class.html"
-  },
-  {
-    "date": "09/03/2020",
-    "observer": "אלחי47",
-    "title": "שום שעיר",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שומרון-שמורת עינות פצאל"
-    ],
-    "flowers": [
-      "שום שעיר"
-    ],
-    "geocoded_locations": {
-      "שומרון-שמורת עינות פצאל": {
         "latitude": 664897.0,
         "longitude": 236037.0
       }
@@ -19562,40 +18581,6 @@
     "source_file": "tiuli_scraped_reports/page_158_report_1_class.html"
   },
   {
-    "date": "20/11/2009",
-    "observer": "המטייל האנונימי",
-    "title": "חלמונית גדולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "דרך מעגלית בהר תבור מובילה לשביל החלמוניות"
-    ],
-    "flowers": [
-      "חלמונית גדולה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_158_report_1_class.html"
-  },
-  {
-    "date": "20/11/2009",
-    "observer": "המטייל האנונימי",
-    "title": "חלמונית גדולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "ירוחם"
-    ],
-    "flowers": [
-      "חלמונית גדולה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_158_report_1_class.html"
-  },
-  {
     "date": "19/11/2009",
     "observer": "המטייל האנונימי",
     "title": "נרקיס מצוי",
@@ -19682,74 +18667,6 @@
   },
   {
     "date": "14/11/2009",
-    "observer": "המטייל האנונימי",
-    "title": "חלמונית גדולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "להבים"
-    ],
-    "flowers": [
-      "חלמונית גדולה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_158_report_1_class.html"
-  },
-  {
-    "date": "14/11/2009",
-    "observer": "המטייל האנונימי",
-    "title": "חלמונית גדולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שביל החלמוניות הר תבור"
-    ],
-    "flowers": [
-      "חלמונית גדולה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_158_report_1_class.html"
-  },
-  {
-    "date": "14/11/2009",
-    "observer": "המטייל האנונימי",
-    "title": "חלמונית גדולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מצפה השלום, כפר חרוב"
-    ],
-    "flowers": [
-      "חלמונית גדולה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_158_report_1_class.html"
-  },
-  {
-    "date": "14/11/2009",
-    "observer": "המטייל האנונימי",
-    "title": "חלמונית גדולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער להב"
-    ],
-    "flowers": [
-      "חלמונית גדולה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_158_report_1_class.html"
-  },
-  {
-    "date": "14/11/2009",
     "observer": "mosherr10",
     "title": "חלמונית גדולה",
     "description": [
@@ -19757,23 +18674,6 @@
     ],
     "locations": [
       "יער להב"
-    ],
-    "flowers": [
-      "חלמונית גדולה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_158_report_1_class.html"
-  },
-  {
-    "date": "14/11/2009",
-    "observer": "המטייל האנונימי",
-    "title": "חלמונית גדולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל קידרון / מנזר מר סבא"
     ],
     "flowers": [
       "חלמונית גדולה"
@@ -19828,23 +18728,6 @@
     ],
     "flowers": [
       "סתוונית היורה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_158_report_1_class.html"
-  },
-  {
-    "date": "13/11/2009",
-    "observer": "המטייל האנונימי",
-    "title": "נרקיס מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "רכס התותחים פארק קנדה"
-    ],
-    "flowers": [
-      "נרקיס מצוי"
     ],
     "geocoded_locations": {},
     "coordinates": [],
@@ -20040,23 +18923,6 @@
   {
     "date": "07/11/2009",
     "observer": "המטייל האנונימי",
-    "title": "חלמונית גדולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "רכס בשנית"
-    ],
-    "flowers": [
-      "חלמונית גדולה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_158_report_1_class.html"
-  },
-  {
-    "date": "07/11/2009",
-    "observer": "המטייל האנונימי",
     "title": "רקפת מצויה",
     "description": [
       ""
@@ -20125,23 +18991,6 @@
   {
     "date": "07/11/2009",
     "observer": "המטייל האנונימי",
-    "title": "חלמונית גדולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "להבים"
-    ],
-    "flowers": [
-      "חלמונית גדולה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_158_report_1_class.html"
-  },
-  {
-    "date": "07/11/2009",
-    "observer": "המטייל האנונימי",
     "title": "סתוונית היורה",
     "description": [
       ""
@@ -20151,23 +19000,6 @@
     ],
     "flowers": [
       "סתוונית היורה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_158_report_1_class.html"
-  },
-  {
-    "date": "07/11/2009",
-    "observer": "המטייל האנונימי",
-    "title": "רקפת מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שביל  מערות ישח"
-    ],
-    "flowers": [
-      "רקפת מצויה"
     ],
     "geocoded_locations": {},
     "coordinates": [],
@@ -20210,46 +19042,12 @@
   {
     "date": "07/11/2009",
     "observer": "המטייל האנונימי",
-    "title": "חלמונית גדולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער להב"
-    ],
-    "flowers": [
-      "חלמונית גדולה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_158_report_1_class.html"
-  },
-  {
-    "date": "07/11/2009",
-    "observer": "המטייל האנונימי",
     "title": "סתוונית בכירה",
     "description": [
       ""
     ],
     "locations": [
       "נחל אורן"
-    ],
-    "flowers": [
-      "סתוונית בכירה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_158_report_1_class.html"
-  },
-  {
-    "date": "07/11/2009",
-    "observer": "המטייל האנונימי",
-    "title": "סתוונית בכירה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "רמת הנדיב- מסלול הנשרים"
     ],
     "flowers": [
       "סתוונית בכירה"
@@ -20806,28 +19604,6 @@
   {
     "date": "21/02/2014",
     "observer": "גדי פולק",
-    "title": "מקור-חסידה מפוצל",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "כורכר גברעם בחלק הצפוני ליד אתר גברעם הישנה"
-    ],
-    "flowers": [
-      "מקור-חסידה מפוצל"
-    ],
-    "geocoded_locations": {
-      "כורכר גברעם בחלק הצפוני ליד אתר גברעם הישנה": {
-        "latitude": 31.5909,
-        "longitude": 34.598
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_92_report_1_class.html"
-  },
-  {
-    "date": "21/02/2014",
-    "observer": "גדי פולק",
     "title": "כרוב החוף",
     "description": [
       ""
@@ -20881,28 +19657,6 @@
     ],
     "flowers": [
       "אלקנת הצבעים"
-    ],
-    "geocoded_locations": {
-      "כורכר גברעם בחלק הצפוני ליד אתר גברעם הישנה": {
-        "latitude": 31.5909,
-        "longitude": 34.598
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_92_report_1_class.html"
-  },
-  {
-    "date": "21/02/2014",
-    "observer": "גדי פולק",
-    "title": "חבלבל החוף",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "כורכר גברעם בחלק הצפוני ליד אתר גברעם הישנה"
-    ],
-    "flowers": [
-      "חבלבל החוף"
     ],
     "geocoded_locations": {
       "כורכר גברעם בחלק הצפוני ליד אתר גברעם הישנה": {
@@ -21048,28 +19802,6 @@
   {
     "date": "21/02/2014",
     "observer": "גדי פולק",
-    "title": "לופית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "כורכר גברעם בחלק הצפוני ליד אתר גברעם הישנה"
-    ],
-    "flowers": [
-      "לופית מצויה"
-    ],
-    "geocoded_locations": {
-      "כורכר גברעם בחלק הצפוני ליד אתר גברעם הישנה": {
-        "latitude": 31.5909,
-        "longitude": 34.598
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_92_report_1_class.html"
-  },
-  {
-    "date": "21/02/2014",
-    "observer": "גדי פולק",
     "title": "מצלתיים מצויות",
     "description": [
       ""
@@ -21202,28 +19934,6 @@
   {
     "date": "21/02/2014",
     "observer": "גדי פולק",
-    "title": "לשון-שור מגובבת",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "כורכר גברעם בחלק הצפוני ליד אתר גברעם הישנה"
-    ],
-    "flowers": [
-      "לשון-שור מגובבת"
-    ],
-    "geocoded_locations": {
-      "כורכר גברעם בחלק הצפוני ליד אתר גברעם הישנה": {
-        "latitude": 31.5909,
-        "longitude": 34.598
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_92_report_1_class.html"
-  },
-  {
-    "date": "21/02/2014",
-    "observer": "גדי פולק",
     "title": "קצח השדה",
     "description": [
       ""
@@ -21246,28 +19956,6 @@
   {
     "date": "21/02/2014",
     "observer": "גדי פולק",
-    "title": "חורשף צהוב",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "כורכר גברעם בחלק הצפוני ליד אתר גברעם הישנה"
-    ],
-    "flowers": [
-      "חורשף צהוב"
-    ],
-    "geocoded_locations": {
-      "כורכר גברעם בחלק הצפוני ליד אתר גברעם הישנה": {
-        "latitude": 31.5909,
-        "longitude": 34.598
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_92_report_1_class.html"
-  },
-  {
-    "date": "21/02/2014",
-    "observer": "גדי פולק",
     "title": "תמריר מרוקני",
     "description": [
       ""
@@ -21277,28 +19965,6 @@
     ],
     "flowers": [
       "תמריר מרוקני"
-    ],
-    "geocoded_locations": {
-      "כורכר גברעם בחלק הצפוני ליד אתר גברעם הישנה": {
-        "latitude": 31.5909,
-        "longitude": 34.598
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_92_report_1_class.html"
-  },
-  {
-    "date": "21/02/2014",
-    "observer": "גדי פולק",
-    "title": "פרסיון גדול",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "כורכר גברעם בחלק הצפוני ליד אתר גברעם הישנה"
-    ],
-    "flowers": [
-      "פרסיון גדול"
     ],
     "geocoded_locations": {
       "כורכר גברעם בחלק הצפוני ליד אתר גברעם הישנה": {
@@ -21646,28 +20312,6 @@
   {
     "date": "13/12/2011",
     "observer": "גדי פולק",
-    "title": "אספרג ארוך-עלים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הר הבנים רמת-גן"
-    ],
-    "flowers": [
-      "אספרג ארוך-עלים"
-    ],
-    "geocoded_locations": {
-      "הר הבנים רמת-גן": {
-        "latitude": 32.0776,
-        "longitude": 34.822
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_127_report_1_class.html"
-  },
-  {
-    "date": "13/12/2011",
-    "observer": "גדי פולק",
     "title": "שרביטן ריסני",
     "description": [
       ""
@@ -21677,72 +20321,6 @@
     ],
     "flowers": [
       "שרביטן ריסני"
-    ],
-    "geocoded_locations": {
-      "הר הבנים רמת-גן": {
-        "latitude": 32.0776,
-        "longitude": 34.822
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_127_report_1_class.html"
-  },
-  {
-    "date": "13/12/2011",
-    "observer": "גדי פולק",
-    "title": "רותם המדבר",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הר הבנים רמת-גן"
-    ],
-    "flowers": [
-      "רותם המדבר"
-    ],
-    "geocoded_locations": {
-      "הר הבנים רמת-גן": {
-        "latitude": 32.0776,
-        "longitude": 34.822
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_127_report_1_class.html"
-  },
-  {
-    "date": "13/12/2011",
-    "observer": "גדי פולק",
-    "title": "קידה שעירה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הר הבנים רמת-גן"
-    ],
-    "flowers": [
-      "קידה שעירה"
-    ],
-    "geocoded_locations": {
-      "הר הבנים רמת-גן": {
-        "latitude": 32.0776,
-        "longitude": 34.822
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_127_report_1_class.html"
-  },
-  {
-    "date": "13/12/2011",
-    "observer": "גדי פולק",
-    "title": "צמרנית הסלעים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הר הבנים רמת-גן"
-    ],
-    "flowers": [
-      "צמרנית הסלעים"
     ],
     "geocoded_locations": {
       "הר הבנים רמת-גן": {
@@ -21985,28 +20563,6 @@
     ],
     "flowers": [
       "פרסיון גדול"
-    ],
-    "geocoded_locations": {
-      "הר הבנים רמת-גן": {
-        "latitude": 32.0776,
-        "longitude": 34.822
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_127_report_1_class.html"
-  },
-  {
-    "date": "13/12/2011",
-    "observer": "גדי פולק",
-    "title": "שמשון סגלגל",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הר הבנים רמת-גן"
-    ],
-    "flowers": [
-      "שמשון סגלגל"
     ],
     "geocoded_locations": {
       "הר הבנים רמת-גן": {
@@ -22774,23 +21330,6 @@
   {
     "date": "22/03/2009",
     "observer": "המטייל האנונימי",
-    "title": "בן-חצב יקינתוני",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שמורת בני ציון, חרוצים"
-    ],
-    "flowers": [
-      "בן-חצב יקינתוני"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_163_report_1_class.html"
-  },
-  {
-    "date": "22/03/2009",
-    "observer": "המטייל האנונימי",
     "title": "דבורנית דינסמור",
     "description": [
       ""
@@ -23527,28 +22066,6 @@
   {
     "date": "07/03/2023",
     "observer": "Iddo_3270859",
-    "title": "רקפת מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "אנדרטת מגילת האש"
-    ],
-    "flowers": [
-      "רקפת מצויה"
-    ],
-    "geocoded_locations": {
-      "אנדרטת מגילת האש": {
-        "latitude": 31.77242820000001,
-        "longitude": 35.0442781
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_16_report_1_class.html"
-  },
-  {
-    "date": "07/03/2023",
-    "observer": "Iddo_3270859",
     "title": "כלנית מצויה",
     "description": [
       ""
@@ -23593,28 +22110,6 @@
   {
     "date": "07/03/2023",
     "observer": "Iddo_3270859",
-    "title": "סחלב פרפרני",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הר איתן"
-    ],
-    "flowers": [
-      "סחלב פרפרני"
-    ],
-    "geocoded_locations": {
-      "הר איתן": {
-        "latitude": 31.7694444,
-        "longitude": 35.1119444
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_16_report_1_class.html"
-  },
-  {
-    "date": "07/03/2023",
-    "observer": "Iddo_3270859",
     "title": "צהרון מצוי",
     "description": [
       ""
@@ -23624,28 +22119,6 @@
     ],
     "flowers": [
       "צהרון מצוי"
-    ],
-    "geocoded_locations": {
-      "הר איתן": {
-        "latitude": 31.7694444,
-        "longitude": 35.1119444
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_16_report_1_class.html"
-  },
-  {
-    "date": "07/03/2023",
-    "observer": "Iddo_3270859",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הר איתן"
-    ],
-    "flowers": [
-      "כלנית מצויה"
     ],
     "geocoded_locations": {
       "הר איתן": {
@@ -23673,28 +22146,6 @@
       "חניון סטף עליון, ירושלים": {
         "latitude": 31.77641517250171,
         "longitude": 35.12701082362782
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_16_report_1_class.html"
-  },
-  {
-    "date": "07/03/2023",
-    "observer": "Iddo_3270859",
-    "title": "סחלב אנטולי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "אנדרטת מגילת האש"
-    ],
-    "flowers": [
-      "סחלב אנטולי"
-    ],
-    "geocoded_locations": {
-      "אנדרטת מגילת האש": {
-        "latitude": 31.77242820000001,
-        "longitude": 35.0442781
       }
     },
     "coordinates": [],
@@ -23739,94 +22190,6 @@
       "אזור תעשייה, מבשרת ציון": {
         "latitude": 31.791156,
         "longitude": 35.143429
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_16_report_1_class.html"
-  },
-  {
-    "date": "07/03/2023",
-    "observer": "Iddo_3270859",
-    "title": "כליל החורש",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "כביש 395/כביש 386, ירושלים"
-    ],
-    "flowers": [
-      "כליל החורש"
-    ],
-    "geocoded_locations": {
-      "כביש 395/כביש 386, ירושלים": {
-        "latitude": 31.772833,
-        "longitude": 35.15361000000001
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_16_report_1_class.html"
-  },
-  {
-    "date": "07/03/2023",
-    "observer": "Iddo_3270859",
-    "title": "כליל החורש",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "אשתאול"
-    ],
-    "flowers": [
-      "כליל החורש"
-    ],
-    "geocoded_locations": {
-      "אשתאול": {
-        "latitude": 31.780385,
-        "longitude": 35.010102
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_16_report_1_class.html"
-  },
-  {
-    "date": "07/03/2023",
-    "observer": "Iddo_3270859",
-    "title": "כליל החורש",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מחלף ענבה"
-    ],
-    "flowers": [
-      "כליל החורש"
-    ],
-    "geocoded_locations": {
-      "מחלף ענבה": {
-        "latitude": 31.8995912,
-        "longitude": 34.93805570000001
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_16_report_1_class.html"
-  },
-  {
-    "date": "07/03/2023",
-    "observer": "Iddo_3270859",
-    "title": "כליל החורש",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חניון סטף עליון, ירושלים"
-    ],
-    "flowers": [
-      "כליל החורש"
-    ],
-    "geocoded_locations": {
-      "חניון סטף עליון, ירושלים": {
-        "latitude": 31.77535760000001,
-        "longitude": 35.1271423
       }
     },
     "coordinates": [],
@@ -24069,28 +22432,6 @@
       "פארק איילון קנדה": {
         "latitude": 31.841621,
         "longitude": 34.993653
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_16_report_1_class.html"
-  },
-  {
-    "date": "04/03/2023",
-    "observer": "Iddo_3270859",
-    "title": "כליל החורש",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שדרות החשמונאים, מודיעין מכבים רעות"
-    ],
-    "flowers": [
-      "כליל החורש"
-    ],
-    "geocoded_locations": {
-      "שדרות החשמונאים, מודיעין מכבים רעות": {
-        "latitude": 31.865794894352245,
-        "longitude": 35.00336133894858
       }
     },
     "coordinates": [],
@@ -24495,28 +22836,6 @@
   {
     "date": "26/03/2021",
     "observer": "Iddo_3270859",
-    "title": "סחלב פרפרני",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "גבעת יערים"
-    ],
-    "flowers": [
-      "סחלב פרפרני"
-    ],
-    "geocoded_locations": {
-      "גבעת יערים": {
-        "latitude": 31.786089,
-        "longitude": 35.09277
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_37_report_1_class.html"
-  },
-  {
-    "date": "26/03/2021",
-    "observer": "Iddo_3270859",
     "title": "סחלב הגליל",
     "description": [
       ""
@@ -24531,28 +22850,6 @@
       "גבעת יערים": {
         "latitude": 31.786089,
         "longitude": 35.09277
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_37_report_1_class.html"
-  },
-  {
-    "date": "26/03/2021",
-    "observer": "Iddo_3270859",
-    "title": "סחלב הגליל",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הר הטייסים"
-    ],
-    "flowers": [
-      "סחלב הגליל"
-    ],
-    "geocoded_locations": {
-      "הר הטייסים": {
-        "latitude": 31.77444399999999,
-        "longitude": 35.09
       }
     },
     "coordinates": [],
@@ -25198,28 +23495,6 @@
   },
   {
     "date": "16/03/2021",
-    "observer": "יודגימל",
-    "title": "אירוס החרמון",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "צומת המפלים, רמת הגולן"
-    ],
-    "flowers": [
-      "אירוס החרמון"
-    ],
-    "geocoded_locations": {
-      "צומת המפלים, רמת הגולן": {
-        "latitude": 33.05067354564283,
-        "longitude": 35.72338320037285
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_37_report_1_class.html"
-  },
-  {
-    "date": "16/03/2021",
     "observer": "zamirsh",
     "title": "לוף ארץ-ישראלי",
     "description": [
@@ -25252,57 +23527,6 @@
     ],
     "flowers": [
       "דבורנית הקטיפה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_90_report_1_class.html"
-  },
-  {
-    "date": "23/03/2014",
-    "observer": "אלחי47",
-    "title": "דבורנית הקטיפה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "גברעם"
-    ],
-    "flowers": [
-      "דבורנית הקטיפה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_90_report_1_class.html"
-  },
-  {
-    "date": "23/03/2014",
-    "observer": "אלחי47",
-    "title": "צבעוני ההרים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "גברעם"
-    ],
-    "flowers": [
-      "צבעוני ההרים"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_90_report_1_class.html"
-  },
-  {
-    "date": "23/03/2014",
-    "observer": "אלחי47",
-    "title": "צבעוני ההרים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "גברעם"
-    ],
-    "flowers": [
-      "צבעוני ההרים"
     ],
     "geocoded_locations": {},
     "coordinates": [],
@@ -25802,40 +24026,6 @@
     "source_file": "tiuli_scraped_reports/page_90_report_1_class.html"
   },
   {
-    "date": "07/03/2014",
-    "observer": "אלחי47",
-    "title": "אירוס נצרתי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שמורת גבעת המורה"
-    ],
-    "flowers": [
-      "אירוס נצרתי"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_90_report_1_class.html"
-  },
-  {
-    "date": "07/03/2014",
-    "observer": "אלחי47",
-    "title": "אירוס נצרתי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שמורת גבעת המורה"
-    ],
-    "flowers": [
-      "אירוס נצרתי"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_90_report_1_class.html"
-  },
-  {
     "date": "06/03/2014",
     "observer": "אלחי47",
     "title": "יחנוק המלחות",
@@ -25861,23 +24051,6 @@
     ],
     "locations": [
       "כביש 211 (באר-שבע-ניצנה)  בקילוטר ה-132 צד ימין"
-    ],
-    "flowers": [
-      "אירוס הנגב"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_90_report_1_class.html"
-  },
-  {
-    "date": "06/03/2014",
-    "observer": "אלחי47",
-    "title": "אירוס הנגב",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "כביש 222 מערבה-אחרי רביבים בקילומטר 163"
     ],
     "flowers": [
       "אירוס הנגב"
@@ -26191,28 +24364,6 @@
   {
     "date": "14/02/2024",
     "observer": "אביטל טביב",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שלולית החורף נתניה, רחוב קרל פופר, נתניה"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "שלולית החורף נתניה, רחוב קרל פופר, נתניה": {
-        "latitude": 32.29180100000001,
-        "longitude": 34.847814
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_7_report_1_class.html"
-  },
-  {
-    "date": "14/02/2024",
-    "observer": "אביטל טביב",
     "title": "תורמוס ארץ-ישראלי",
     "description": [
       ""
@@ -26293,50 +24444,6 @@
       "דרך 1, ירושלים": {
         "latitude": 31.796732,
         "longitude": 35.1777742
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_7_report_1_class.html"
-  },
-  {
-    "date": "13/02/2024",
-    "observer": "Iddo_3270859",
-    "title": "שקד מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "כביש 395/כביש 386, ירושלים"
-    ],
-    "flowers": [
-      "שקד מצוי"
-    ],
-    "geocoded_locations": {
-      "כביש 395/כביש 386, ירושלים": {
-        "latitude": 31.772833,
-        "longitude": 35.15361000000001
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_7_report_1_class.html"
-  },
-  {
-    "date": "13/02/2024",
-    "observer": "Iddo_3270859",
-    "title": "שקד מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "עין כרם, ירושלים"
-    ],
-    "flowers": [
-      "שקד מצוי"
-    ],
-    "geocoded_locations": {
-      "עין כרם, ירושלים": {
-        "latitude": 31.7671028,
-        "longitude": 35.1623714
       }
     },
     "coordinates": [],
@@ -26673,28 +24780,6 @@
     "source_file": "tiuli_scraped_reports/page_7_report_1_class.html"
   },
   {
-    "date": "02/02/2024",
-    "observer": "Iddo_3270859",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "תל בית שמש, בית שמש"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "תל בית שמש, בית שמש": {
-        "latitude": 31.75030299999999,
-        "longitude": 34.975495
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_7_report_1_class.html"
-  },
-  {
     "date": "27/01/2024",
     "observer": "Iddo_3270859",
     "title": "כלנית מצויה",
@@ -26711,28 +24796,6 @@
       "מצפור סיון, שדרות יצחק רבין, יוקנעם עילית": {
         "latitude": 32.6420474,
         "longitude": 35.0936419
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_7_report_1_class.html"
-  },
-  {
-    "date": "27/01/2024",
-    "observer": "Iddo_3270859",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "דליה"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "דליה": {
-        "latitude": 32.597099273449984,
-        "longitude": 35.08328801995211
       }
     },
     "coordinates": [],
@@ -26975,50 +25038,6 @@
       "גבעת ברפיליה, חיים בר-לב, מודיעין מכבים רעות": {
         "latitude": 31.9090429,
         "longitude": 34.998517
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_7_report_1_class.html"
-  },
-  {
-    "date": "20/01/2024",
-    "observer": "Iddo_3270859",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "גבעת התיתורה, דרך יגאל אלון, מודיעין מכבים רעות"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "גבעת התיתורה, דרך יגאל אלון, מודיעין מכבים רעות": {
-        "latitude": 31.9027054,
-        "longitude": 35.0176871
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_7_report_1_class.html"
-  },
-  {
-    "date": "20/01/2024",
-    "observer": "Iddo_3270859",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חורבת נכס, המכונאי, מודיעין מכבים רעות"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "חורבת נכס, המכונאי, מודיעין מכבים רעות": {
-        "latitude": 31.88852799999999,
-        "longitude": 34.957661
       }
     },
     "coordinates": [],
@@ -27331,23 +25350,6 @@
     ],
     "flowers": [
       "פגוניה ערבית"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_96_report_1_class.html"
-  },
-  {
-    "date": "12/02/2014",
-    "observer": "אלחי47",
-    "title": "טוריים מדבריים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק תמנע"
-    ],
-    "flowers": [
-      "טוריים מדבריים"
     ],
     "geocoded_locations": {},
     "coordinates": [],
@@ -27814,23 +25816,6 @@
   },
   {
     "date": "08/02/2014",
-    "observer": "eladhil2",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער שוקדה"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_96_report_1_class.html"
-  },
-  {
-    "date": "08/02/2014",
     "observer": "noa kali",
     "title": "דודא רפואי",
     "description": [
@@ -27906,23 +25891,6 @@
     ],
     "locations": [
       "שמורת בית עובד"
-    ],
-    "flowers": [
-      "אירוס הארגמן"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_96_report_1_class.html"
-  },
-  {
-    "date": "07/02/2014",
-    "observer": "נעם ב",
-    "title": "אירוס הארגמן",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נס ציונה - דרך גבעות הכורכר פינת רח'' המאה ואחד"
     ],
     "flowers": [
       "אירוס הארגמן"
@@ -28735,28 +26703,6 @@
       "יער הנשיא - דרך הפסלים": {
         "latitude": 31.7796,
         "longitude": 34.9899
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_80_report_1_class.html"
-  },
-  {
-    "date": "09/02/2015",
-    "observer": "עידו מגן",
-    "title": "רקפת מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חניון חנה וגרשון הדס, ליד מערת הנטיפים"
-    ],
-    "flowers": [
-      "רקפת מצויה"
-    ],
-    "geocoded_locations": {
-      "חניון חנה וגרשון הדס, ליד מערת הנטיפים": {
-        "latitude": 31.7471,
-        "longitude": 35.035
       }
     },
     "coordinates": [],
@@ -29911,28 +27857,6 @@
   {
     "date": "04/06/2013",
     "observer": "גדי פולק",
-    "title": "חנק מחודד",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מלחת הנעמן מצפון לתוואי רכבת עכו - כרמיאל"
-    ],
-    "flowers": [
-      "חנק מחודד"
-    ],
-    "geocoded_locations": {
-      "מלחת הנעמן מצפון לתוואי רכבת עכו - כרמיאל": {
-        "latitude": 32.912,
-        "longitude": 35.087
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_104_report_1_class.html"
-  },
-  {
-    "date": "04/06/2013",
-    "observer": "גדי פולק",
     "title": "אספרג ארץ-ישראלי",
     "description": [
       ""
@@ -30228,28 +28152,6 @@
     ],
     "flowers": [
       "תלתן הביצות"
-    ],
-    "geocoded_locations": {
-      "כרי נעמן - שוליים צפוניים-מזרחיים של השטח המוצף": {
-        "latitude": 32.8732,
-        "longitude": 35.1059
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_104_report_1_class.html"
-  },
-  {
-    "date": "04/06/2013",
-    "observer": "גדי פולק",
-    "title": "חנק מחודד",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "כרי נעמן - שוליים צפוניים-מזרחיים של השטח המוצף"
-    ],
-    "flowers": [
-      "חנק מחודד"
     ],
     "geocoded_locations": {
       "כרי נעמן - שוליים צפוניים-מזרחיים של השטח המוצף": {
@@ -30569,28 +28471,6 @@
     "source_file": "tiuli_scraped_reports/page_104_report_1_class.html"
   },
   {
-    "date": "04/06/2013",
-    "observer": "גדי פולק",
-    "title": "תלתן הביצות",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "גן התומר - עין המפרץ"
-    ],
-    "flowers": [
-      "תלתן הביצות"
-    ],
-    "geocoded_locations": {
-      "גן התומר - עין המפרץ": {
-        "latitude": 32.9046,
-        "longitude": 35.1014
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_104_report_1_class.html"
-  },
-  {
     "date": "23/05/2013",
     "observer": "אלחי47",
     "title": "בוצין קיסריון",
@@ -30619,23 +28499,6 @@
     ],
     "flowers": [
       "שברק דביק"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_104_report_1_class.html"
-  },
-  {
-    "date": "22/05/2013",
-    "observer": "אלחי47",
-    "title": "קרקש קיליקי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל גובתה  עליון (בשביל השחור היורד מנוה אטיב)"
-    ],
-    "flowers": [
-      "קרקש קיליקי"
     ],
     "geocoded_locations": {},
     "coordinates": [],
@@ -31254,28 +29117,6 @@
   {
     "date": "24/02/2024",
     "observer": "Iddo_3270859",
-    "title": "רקפת מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "תל שוכה - גבעת התורמוסים"
-    ],
-    "flowers": [
-      "רקפת מצויה"
-    ],
-    "geocoded_locations": {
-      "תל שוכה - גבעת התורמוסים": {
-        "latitude": 31.6848654,
-        "longitude": 34.9705764
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_6_report_1_class.html"
-  },
-  {
-    "date": "24/02/2024",
-    "observer": "Iddo_3270859",
     "title": "כלנית מצויה",
     "description": [
       ""
@@ -31320,28 +29161,6 @@
   {
     "date": "24/02/2024",
     "observer": "Iddo_3270859",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק עדולם"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "פארק עדולם": {
-        "latitude": 31.64474300000001,
-        "longitude": 34.960909
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_6_report_1_class.html"
-  },
-  {
-    "date": "24/02/2024",
-    "observer": "Iddo_3270859",
     "title": "סחלב פרפרני",
     "description": [
       ""
@@ -31378,72 +29197,6 @@
       "בית שמש": {
         "latitude": 31.747041,
         "longitude": 34.988099
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_6_report_1_class.html"
-  },
-  {
-    "date": "24/02/2024",
-    "observer": "Iddo_3270859",
-    "title": "שקד מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מיני ישראל"
-    ],
-    "flowers": [
-      "שקד מצוי"
-    ],
-    "geocoded_locations": {
-      "מיני ישראל": {
-        "latitude": 31.8421649,
-        "longitude": 34.9690158
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_6_report_1_class.html"
-  },
-  {
-    "date": "24/02/2024",
-    "observer": "Iddo_3270859",
-    "title": "שקד מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חניון הפרפר, כביש 353"
-    ],
-    "flowers": [
-      "שקד מצוי"
-    ],
-    "geocoded_locations": {
-      "חניון הפרפר, כביש 353": {
-        "latitude": 31.6842263,
-        "longitude": 34.9273774
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_6_report_1_class.html"
-  },
-  {
-    "date": "24/02/2024",
-    "observer": "Iddo_3270859",
-    "title": "שקד מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "אנדרטת לוחמי הלחי, משמר איילון"
-    ],
-    "flowers": [
-      "שקד מצוי"
-    ],
-    "geocoded_locations": {
-      "אנדרטת לוחמי הלחי, משמר איילון": {
-        "latitude": 31.86803649999999,
-        "longitude": 34.9511059
       }
     },
     "coordinates": [],
@@ -31554,50 +29307,6 @@
       "הזורע": {
         "latitude": 32.644516,
         "longitude": 35.11918
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_6_report_1_class.html"
-  },
-  {
-    "date": "23/02/2024",
-    "observer": "Iddo_3270859",
-    "title": "רקפת מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל השופט"
-    ],
-    "flowers": [
-      "רקפת מצויה"
-    ],
-    "geocoded_locations": {
-      "נחל השופט": {
-        "latitude": 32.628333,
-        "longitude": 35.105822
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_6_report_1_class.html"
-  },
-  {
-    "date": "23/02/2024",
-    "observer": "Iddo_3270859",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל השופט"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "נחל השופט": {
-        "latitude": 32.635726619663,
-        "longitude": 35.114684784088695
       }
     },
     "coordinates": [],
@@ -31738,28 +29447,6 @@
   {
     "date": "17/02/2024",
     "observer": "Iddo_3270859",
-    "title": "שקד מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מבוא חורון"
-    ],
-    "flowers": [
-      "שקד מצוי"
-    ],
-    "geocoded_locations": {
-      "מבוא חורון": {
-        "latitude": 31.849598,
-        "longitude": 35.034977
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_6_report_1_class.html"
-  },
-  {
-    "date": "17/02/2024",
-    "observer": "Iddo_3270859",
     "title": "תורמוס ההרים",
     "description": [
       ""
@@ -31774,50 +29461,6 @@
       "חורבת שרישה": {
         "latitude": 31.821855,
         "longitude": 34.939473
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_6_report_1_class.html"
-  },
-  {
-    "date": "17/02/2024",
-    "observer": "Iddo_3270859",
-    "title": "תורמוס ההרים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "תל קטרה, גדרה"
-    ],
-    "flowers": [
-      "תורמוס ההרים"
-    ],
-    "geocoded_locations": {
-      "תל קטרה, גדרה": {
-        "latitude": 31.82276,
-        "longitude": 34.777344
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_6_report_1_class.html"
-  },
-  {
-    "date": "17/02/2024",
-    "observer": "Iddo_3270859",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "אנדרטת חטיבת אלכסנדרוני קרב לטרון"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "אנדרטת חטיבת אלכסנדרוני קרב לטרון": {
-        "latitude": 31.8274329,
-        "longitude": 34.96432610000001
       }
     },
     "coordinates": [],
@@ -33042,28 +30685,6 @@
     "source_file": "tiuli_scraped_reports/page_26_report_1_class.html"
   },
   {
-    "date": "16/04/2022",
-    "observer": "Iddo_3270859",
-    "title": "פרג אגסי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "כביש 42/בית חנן, נס ציונה"
-    ],
-    "flowers": [
-      "פרג אגסי"
-    ],
-    "geocoded_locations": {
-      "כביש 42/בית חנן, נס ציונה": {
-        "latitude": 31.892000392157428,
-        "longitude": 34.759051388570136
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_26_report_1_class.html"
-  },
-  {
     "date": "15/04/2022",
     "observer": "נק999",
     "title": "אירוס הגלבוע",
@@ -33080,28 +30701,6 @@
       "מלכישוע": {
         "latitude": 32.43463474235588,
         "longitude": 35.415955953345396
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_26_report_1_class.html"
-  },
-  {
-    "date": "15/04/2022",
-    "observer": "נק999",
-    "title": "אירוס הגלבוע",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הר ברקן"
-    ],
-    "flowers": [
-      "אירוס הגלבוע"
-    ],
-    "geocoded_locations": {
-      "הר ברקן": {
-        "latitude": 32.50526324129528,
-        "longitude": 35.409900692441305
       }
     },
     "coordinates": [],
@@ -33433,28 +31032,6 @@
     "source_file": "tiuli_scraped_reports/page_26_report_1_class.html"
   },
   {
-    "date": "10/04/2022",
-    "observer": "אלחי47",
-    "title": "סחלב איטלקי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הר מירון"
-    ],
-    "flowers": [
-      "סחלב איטלקי"
-    ],
-    "geocoded_locations": {
-      "הר מירון": {
-        "latitude": 32.999,
-        "longitude": 35.395
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_26_report_1_class.html"
-  },
-  {
     "date": "09/04/2022",
     "observer": "אלחי47",
     "title": "דרדר כחול",
@@ -33697,28 +31274,6 @@
     "source_file": "tiuli_scraped_reports/page_26_report_1_class.html"
   },
   {
-    "date": "07/04/2022",
-    "observer": "Iddo_3270859",
-    "title": "כליל החורש",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שביל טיילת עמי, עמיר"
-    ],
-    "flowers": [
-      "כליל החורש"
-    ],
-    "geocoded_locations": {
-      "שביל טיילת עמי, עמיר": {
-        "latitude": 33.17776,
-        "longitude": 35.616184
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_26_report_1_class.html"
-  },
-  {
     "date": "06/04/2022",
     "observer": "Iddo_3270859",
     "title": "כליל החורש",
@@ -33831,28 +31386,6 @@
   {
     "date": "06/04/2022",
     "observer": "Iddo_3270859",
-    "title": "סחלב איטלקי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שמורת הר נזר"
-    ],
-    "flowers": [
-      "סחלב איטלקי"
-    ],
-    "geocoded_locations": {
-      "שמורת הר נזר": {
-        "latitude": 33.1738179,
-        "longitude": 35.54526490000001
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_26_report_1_class.html"
-  },
-  {
-    "date": "06/04/2022",
-    "observer": "Iddo_3270859",
     "title": "צהרון מצוי",
     "description": [
       ""
@@ -33867,28 +31400,6 @@
       "מצפה חוסיין": {
         "latitude": 33.1698755,
         "longitude": 35.5508056
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_26_report_1_class.html"
-  },
-  {
-    "date": "06/04/2022",
-    "observer": "Iddo_3270859",
-    "title": "נורית אסיה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל דישון"
-    ],
-    "flowers": [
-      "נורית אסיה"
-    ],
-    "geocoded_locations": {
-      "נחל דישון": {
-        "latitude": 33.06277109999999,
-        "longitude": 35.5267112
       }
     },
     "coordinates": [],
@@ -34084,23 +31595,6 @@
   {
     "date": "28/11/2009",
     "observer": "המטייל האנונימי",
-    "title": "אירוס הסרגל",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "דרך נוף כרמל, מתחת המוחרקה"
-    ],
-    "flowers": [
-      "אירוס הסרגל"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_157_report_1_class.html"
-  },
-  {
-    "date": "28/11/2009",
-    "observer": "המטייל האנונימי",
     "title": "נרקיס מצוי",
     "description": [
       ""
@@ -34141,23 +31635,6 @@
     ],
     "locations": [
       "הר הרוח"
-    ],
-    "flowers": [
-      "נרקיס מצוי"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_157_report_1_class.html"
-  },
-  {
-    "date": "28/11/2009",
-    "observer": "המטייל האנונימי",
-    "title": "נרקיס מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל עמוד עליון"
     ],
     "flowers": [
       "נרקיס מצוי"
@@ -34212,74 +31689,6 @@
     ],
     "flowers": [
       "סתוונית ירושלים"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_157_report_1_class.html"
-  },
-  {
-    "date": "28/11/2009",
-    "observer": "המטייל האנונימי",
-    "title": "נרקיס מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מצוקי (חורשת) הארבעים."
-    ],
-    "flowers": [
-      "נרקיס מצוי"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_157_report_1_class.html"
-  },
-  {
-    "date": "28/11/2009",
-    "observer": "המטייל האנונימי",
-    "title": "רקפת מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מצוקי (חורשת) הארבעים"
-    ],
-    "flowers": [
-      "רקפת מצויה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_157_report_1_class.html"
-  },
-  {
-    "date": "28/11/2009",
-    "observer": "המטייל האנונימי",
-    "title": "אירוס הסרגל",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מצוקי (חורשת) הארבעים"
-    ],
-    "flowers": [
-      "אירוס הסרגל"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_157_report_1_class.html"
-  },
-  {
-    "date": "28/11/2009",
-    "observer": "המטייל האנונימי",
-    "title": "כרכום חורפי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "על המדרון מעל הכביש העולה מצומת אורן לחניון האגם אחרי קמ4"
-    ],
-    "flowers": [
-      "כרכום חורפי"
     ],
     "geocoded_locations": {},
     "coordinates": [],
@@ -34422,23 +31831,6 @@
     "source_file": "tiuli_scraped_reports/page_157_report_1_class.html"
   },
   {
-    "date": "22/11/2009",
-    "observer": "המטייל האנונימי",
-    "title": "נרקיס מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "בירידה מנחל יגור לקיבוץ יגור"
-    ],
-    "flowers": [
-      "נרקיס מצוי"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_157_report_1_class.html"
-  },
-  {
     "date": "21/11/2009",
     "observer": "המטייל האנונימי",
     "title": "נרקיס מצוי",
@@ -34447,23 +31839,6 @@
     ],
     "locations": [
       "אזור מערת בני ברית"
-    ],
-    "flowers": [
-      "נרקיס מצוי"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_157_report_1_class.html"
-  },
-  {
-    "date": "21/11/2009",
-    "observer": "המטייל האנונימי",
-    "title": "נרקיס מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חירבת חני (קולה)"
     ],
     "flowers": [
       "נרקיס מצוי"
@@ -34509,23 +31884,6 @@
   {
     "date": "21/11/2009",
     "observer": "המטייל האנונימי",
-    "title": "נרקיס מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מערת קשת + נחל שרך בצת"
-    ],
-    "flowers": [
-      "נרקיס מצוי"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_157_report_1_class.html"
-  },
-  {
-    "date": "21/11/2009",
-    "observer": "המטייל האנונימי",
     "title": "רקפת מצויה",
     "description": [
       ""
@@ -34560,23 +31918,6 @@
   {
     "date": "21/11/2009",
     "observer": "המטייל האנונימי",
-    "title": "חלמונית גדולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "להבים"
-    ],
-    "flowers": [
-      "חלמונית גדולה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_157_report_1_class.html"
-  },
-  {
-    "date": "21/11/2009",
-    "observer": "המטייל האנונימי",
     "title": "חיננית הבתה",
     "description": [
       ""
@@ -34586,74 +31927,6 @@
     ],
     "flowers": [
       "חיננית הבתה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_157_report_1_class.html"
-  },
-  {
-    "date": "21/11/2009",
-    "observer": "המטייל האנונימי",
-    "title": "נרקיס מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שביל שחור 2333 מחניון הפסגה הר מירון"
-    ],
-    "flowers": [
-      "נרקיס מצוי"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_157_report_1_class.html"
-  },
-  {
-    "date": "21/11/2009",
-    "observer": "המטייל האנונימי",
-    "title": "חלמונית גדולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שביל הפסגה בהר מירון"
-    ],
-    "flowers": [
-      "חלמונית גדולה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_157_report_1_class.html"
-  },
-  {
-    "date": "21/11/2009",
-    "observer": "המטייל האנונימי",
-    "title": "חלמונית גדולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שמורת החלמוניות דרומית לאגם ירוחם"
-    ],
-    "flowers": [
-      "חלמונית גדולה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_157_report_1_class.html"
-  },
-  {
-    "date": "21/11/2009",
-    "observer": "המטייל האנונימי",
-    "title": "כרכום חורפי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "עין זבד"
-    ],
-    "flowers": [
-      "כרכום חורפי"
     ],
     "geocoded_locations": {},
     "coordinates": [],
@@ -34821,23 +32094,6 @@
     ],
     "locations": [
       "ממש לפני מושב שוקדה"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_152_report_1_class.html"
-  },
-  {
-    "date": "06/02/2010",
-    "observer": "המטייל האנונימי",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "גבעת התורמוסים - תל שוכה - עמק האלה"
     ],
     "flowers": [
       "כלנית מצויה"
@@ -35206,40 +32462,6 @@
   {
     "date": "30/01/2010",
     "observer": "המטייל האנונימי",
-    "title": "אירוס הארגמן",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שמורת פולג"
-    ],
-    "flowers": [
-      "אירוס הארגמן"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_152_report_1_class.html"
-  },
-  {
-    "date": "30/01/2010",
-    "observer": "המטייל האנונימי",
-    "title": "אירוס הארגמן",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שמורת אודים - מול מכון ווינגייט"
-    ],
-    "flowers": [
-      "אירוס הארגמן"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_152_report_1_class.html"
-  },
-  {
-    "date": "30/01/2010",
-    "observer": "המטייל האנונימי",
     "title": "אירוס ארץ-ישראלי",
     "description": [
       ""
@@ -35308,23 +32530,6 @@
   {
     "date": "30/01/2010",
     "observer": "המטייל האנונימי",
-    "title": "שקד מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "סטף"
-    ],
-    "flowers": [
-      "שקד מצוי"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_152_report_1_class.html"
-  },
-  {
-    "date": "30/01/2010",
-    "observer": "המטייל האנונימי",
     "title": "רקפת מצויה",
     "description": [
       ""
@@ -35334,23 +32539,6 @@
     ],
     "flowers": [
       "רקפת מצויה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_152_report_1_class.html"
-  },
-  {
-    "date": "30/01/2010",
-    "observer": "המטייל האנונימי",
-    "title": "עירית גדולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "סטף"
-    ],
-    "flowers": [
-      "עירית גדולה"
     ],
     "geocoded_locations": {},
     "coordinates": [],
@@ -35470,23 +32658,6 @@
     ],
     "flowers": [
       "רומולאה סגלולית"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_152_report_1_class.html"
-  },
-  {
-    "date": "29/01/2010",
-    "observer": "המטייל האנונימי",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שמורת גוש אלונים, שמורת אלוני אבא - מצפון לכביש הגישה לבית לחם הגלילית"
-    ],
-    "flowers": [
-      "כלנית מצויה"
     ],
     "geocoded_locations": {},
     "coordinates": [],
@@ -36321,28 +33492,6 @@
   {
     "date": "29/03/2014",
     "observer": "גדי פולק",
-    "title": "חרצית עטורה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "תל יקנעם"
-    ],
-    "flowers": [
-      "חרצית עטורה"
-    ],
-    "geocoded_locations": {
-      "תל יקנעם": {
-        "latitude": 32.6645,
-        "longitude": 35.1085
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_89_report_1_class.html"
-  },
-  {
-    "date": "29/03/2014",
-    "observer": "גדי פולק",
     "title": "מרוות ירושלים",
     "description": [
       ""
@@ -36516,23 +33665,6 @@
     "source_file": "tiuli_scraped_reports/page_89_report_1_class.html"
   },
   {
-    "date": "23/03/2014",
-    "observer": "אלחי47",
-    "title": "דבורנית הקטיפה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "גברעם"
-    ],
-    "flowers": [
-      "דבורנית הקטיפה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_89_report_1_class.html"
-  },
-  {
     "date": "12/03/2007",
     "observer": "המטייל האנונימי",
     "title": "צהרון מצוי",
@@ -36541,23 +33673,6 @@
     ],
     "locations": [
       "גלבוע , כתף שאול"
-    ],
-    "flowers": [
-      "צהרון מצוי"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_185_report_1_class.html"
-  },
-  {
-    "date": "12/03/2007",
-    "observer": "המטייל האנונימי",
-    "title": "צהרון מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "גלבוע , גבעת האירוסים"
     ],
     "flowers": [
       "צהרון מצוי"
@@ -36711,23 +33826,6 @@
     ],
     "locations": [
       "שמורת המסרק"
-    ],
-    "flowers": [
-      "צהרון מצוי"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_185_report_1_class.html"
-  },
-  {
-    "date": "10/03/2007",
-    "observer": "המטייל האנונימי",
-    "title": "צהרון מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל צין, בין מעלה צין לעין עקב"
     ],
     "flowers": [
       "צהרון מצוי"
@@ -37372,50 +34470,6 @@
   },
   {
     "date": "21/03/2015",
-    "observer": "אלחי47",
-    "title": "אירוס נצרתי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הגליל התחתון"
-    ],
-    "flowers": [
-      "אירוס נצרתי"
-    ],
-    "geocoded_locations": {
-      "הגליל התחתון": {
-        "latitude": 32.7253,
-        "longitude": 35.3411
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_77_report_1_class.html"
-  },
-  {
-    "date": "21/03/2015",
-    "observer": "אלחי47",
-    "title": "אירוס נצרתי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הגליל התחתון"
-    ],
-    "flowers": [
-      "אירוס נצרתי"
-    ],
-    "geocoded_locations": {
-      "הגליל התחתון": {
-        "latitude": 32.7253,
-        "longitude": 35.3411
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_77_report_1_class.html"
-  },
-  {
-    "date": "21/03/2015",
     "observer": "עידו מגן",
     "title": "שום תל-אביב",
     "description": [
@@ -37609,28 +34663,6 @@
   },
   {
     "date": "18/03/2015",
-    "observer": "אלחי47",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מרכז הנגב והמכתשים"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "מרכז הנגב והמכתשים": {
-        "latitude": 30.4792,
-        "longitude": 34.6312
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_77_report_1_class.html"
-  },
-  {
-    "date": "18/03/2015",
     "observer": "יוחאי כורם",
     "title": "דרדר כחול",
     "description": [
@@ -37712,72 +34744,6 @@
       "ואדי אל חכם": {
         "latitude": 32.0368,
         "longitude": 35.0631
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_77_report_1_class.html"
-  },
-  {
-    "date": "17/03/2015",
-    "observer": "אלחי47",
-    "title": "ריבס המדבר",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מרכז הנגב והמכתשים"
-    ],
-    "flowers": [
-      "ריבס המדבר"
-    ],
-    "geocoded_locations": {
-      "מרכז הנגב והמכתשים": {
-        "latitude": 30.4937,
-        "longitude": 34.6372
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_77_report_1_class.html"
-  },
-  {
-    "date": "17/03/2015",
-    "observer": "אלחי47",
-    "title": "ריבס המדבר",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מרכז הנגב והמכתשים"
-    ],
-    "flowers": [
-      "ריבס המדבר"
-    ],
-    "geocoded_locations": {
-      "מרכז הנגב והמכתשים": {
-        "latitude": 30.4937,
-        "longitude": 34.6372
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_77_report_1_class.html"
-  },
-  {
-    "date": "17/03/2015",
-    "observer": "אלחי47",
-    "title": "ריבס המדבר",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מרכז הנגב והמכתשים"
-    ],
-    "flowers": [
-      "ריבס המדבר"
-    ],
-    "geocoded_locations": {
-      "מרכז הנגב והמכתשים": {
-        "latitude": 30.4937,
-        "longitude": 34.6372
       }
     },
     "coordinates": [],
@@ -38072,28 +35038,6 @@
   {
     "date": "15/03/2015",
     "observer": "אלחי47",
-    "title": "ריבס המדבר",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מרכז הנגב והמכתשים"
-    ],
-    "flowers": [
-      "ריבס המדבר"
-    ],
-    "geocoded_locations": {
-      "מרכז הנגב והמכתשים": {
-        "latitude": 30.4936,
-        "longitude": 34.637
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_77_report_1_class.html"
-  },
-  {
-    "date": "15/03/2015",
-    "observer": "אלחי47",
     "title": "מוריקה מבריקה",
     "description": [
       ""
@@ -38108,50 +35052,6 @@
       "מרכז הנגב והמכתשים": {
         "latitude": 30.5933,
         "longitude": 34.7095
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_77_report_1_class.html"
-  },
-  {
-    "date": "15/03/2015",
-    "observer": "אלחי47",
-    "title": "עיריוני צהוב",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מרכז הנגב והמכתשים"
-    ],
-    "flowers": [
-      "עיריוני צהוב"
-    ],
-    "geocoded_locations": {
-      "מרכז הנגב והמכתשים": {
-        "latitude": 30.4643,
-        "longitude": 34.6443
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_77_report_1_class.html"
-  },
-  {
-    "date": "15/03/2015",
-    "observer": "אלחי47",
-    "title": "עיריוני צהוב",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מרכז הנגב והמכתשים"
-    ],
-    "flowers": [
-      "עיריוני צהוב"
-    ],
-    "geocoded_locations": {
-      "מרכז הנגב והמכתשים": {
-        "latitude": 30.4643,
-        "longitude": 34.6443
       }
     },
     "coordinates": [],
@@ -38301,28 +35201,6 @@
     ],
     "flowers": [
       "דרדר כחול"
-    ],
-    "geocoded_locations": {
-      "רמות מנשה": {
-        "latitude": 32.8156,
-        "longitude": 34.9892
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_77_report_1_class.html"
-  },
-  {
-    "date": "14/03/2015",
-    "observer": "lzuri",
-    "title": "עכנאי יהודה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "רמות מנשה"
-    ],
-    "flowers": [
-      "עכנאי יהודה"
     ],
     "geocoded_locations": {
       "רמות מנשה": {
@@ -38933,23 +35811,6 @@
   {
     "date": "19/01/2013",
     "observer": "יוחאי כורם",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער קולה"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_117_report_1_class.html"
-  },
-  {
-    "date": "19/01/2013",
-    "observer": "יוחאי כורם",
     "title": "ניסנית דו-קרנית",
     "description": [
       ""
@@ -39233,28 +36094,6 @@
   {
     "date": "19/01/2013",
     "observer": "גדי פולק",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "בין צור יצחק לצור נתן"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "בין צור יצחק לצור נתן": {
-        "latitude": 32.2403,
-        "longitude": 35.007
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_117_report_1_class.html"
-  },
-  {
-    "date": "19/01/2013",
-    "observer": "גדי פולק",
     "title": "רקפת מצויה",
     "description": [
       ""
@@ -39264,72 +36103,6 @@
     ],
     "flowers": [
       "רקפת מצויה"
-    ],
-    "geocoded_locations": {
-      "בין צור יצחק לצור נתן": {
-        "latitude": 32.2403,
-        "longitude": 35.007
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_117_report_1_class.html"
-  },
-  {
-    "date": "19/01/2013",
-    "observer": "גדי פולק",
-    "title": "ניסנית דו-קרנית",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "בין צור יצחק לצור נתן"
-    ],
-    "flowers": [
-      "ניסנית דו-קרנית"
-    ],
-    "geocoded_locations": {
-      "בין צור יצחק לצור נתן": {
-        "latitude": 32.2403,
-        "longitude": 35.007
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_117_report_1_class.html"
-  },
-  {
-    "date": "19/01/2013",
-    "observer": "גדי פולק",
-    "title": "סביון אביבי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "בין צור יצחק לצור נתן"
-    ],
-    "flowers": [
-      "סביון אביבי"
-    ],
-    "geocoded_locations": {
-      "בין צור יצחק לצור נתן": {
-        "latitude": 32.2403,
-        "longitude": 35.007
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_117_report_1_class.html"
-  },
-  {
-    "date": "19/01/2013",
-    "observer": "גדי פולק",
-    "title": "ציפורני-חתול מצויות",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "בין צור יצחק לצור נתן"
-    ],
-    "flowers": [
-      "ציפורני-חתול מצויות"
     ],
     "geocoded_locations": {
       "בין צור יצחק לצור נתן": {
@@ -40420,23 +37193,6 @@
     "source_file": "tiuli_scraped_reports/page_129_report_1_class.html"
   },
   {
-    "date": "01/11/2011",
-    "observer": "המטייל האנונימי",
-    "title": "חלמונית גדולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער להב ליד הישוב להבים"
-    ],
-    "flowers": [
-      "חלמונית גדולה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_129_report_1_class.html"
-  },
-  {
     "date": "31/10/2011",
     "observer": "יאנץ",
     "title": "חלמונית גדולה",
@@ -40530,23 +37286,6 @@
     ],
     "locations": [
       "מבוא חמה"
-    ],
-    "flowers": [
-      "חלמונית גדולה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_129_report_1_class.html"
-  },
-  {
-    "date": "21/10/2011",
-    "observer": "המטייל האנונימי",
-    "title": "חלמונית גדולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שביל הפסגה,  הר מירון"
     ],
     "flowers": [
       "חלמונית גדולה"
@@ -40879,40 +37618,6 @@
     "source_file": "tiuli_scraped_reports/page_129_report_1_class.html"
   },
   {
-    "date": "02/10/2011",
-    "observer": "המטייל האנונימי",
-    "title": "חצב מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "כביש 40 ליד רמת בקע"
-    ],
-    "flowers": [
-      "חצב מצוי"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_129_report_1_class.html"
-  },
-  {
-    "date": "02/10/2011",
-    "observer": "המטייל האנונימי",
-    "title": "חצב מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "כביש 40 ליד רמת בקע"
-    ],
-    "flowers": [
-      "חצב מצוי"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_129_report_1_class.html"
-  },
-  {
     "date": "01/10/2011",
     "observer": "perrysh",
     "title": "חבצלת קטנת-פרחים",
@@ -40955,23 +37660,6 @@
     ],
     "locations": [
       "ביצאה מרמלה לבית שמש כביש 44"
-    ],
-    "flowers": [
-      "חצב מצוי"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_129_report_1_class.html"
-  },
-  {
-    "date": "12/09/2011",
-    "observer": "סימבה גז",
-    "title": "חצב מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "כביש 44 לכיוון בית שמש מול תעוז ולפני תרום"
     ],
     "flowers": [
       "חצב מצוי"
@@ -42167,28 +38855,6 @@
   },
   {
     "date": "22/02/2023",
-    "observer": "מ.פ 1967",
-    "title": "אירוס הארגמן",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "גבעת חומרה, גן שורק"
-    ],
-    "flowers": [
-      "אירוס הארגמן"
-    ],
-    "geocoded_locations": {
-      "גבעת חומרה, גן שורק": {
-        "latitude": 31.9351573,
-        "longitude": 34.7433545
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_18_report_1_class.html"
-  },
-  {
-    "date": "22/02/2023",
     "observer": "אלחי47",
     "title": "אשבל מצרי",
     "description": [
@@ -42270,50 +38936,6 @@
       "יער המלאכים שחריה": {
         "latitude": 31.596106,
         "longitude": 34.830539
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_18_report_1_class.html"
-  },
-  {
-    "date": "21/02/2023",
-    "observer": "Iddo_3270859",
-    "title": "שקד מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "אמציה"
-    ],
-    "flowers": [
-      "שקד מצוי"
-    ],
-    "geocoded_locations": {
-      "אמציה": {
-        "latitude": 31.5374464997631,
-        "longitude": 34.90467772689493
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_18_report_1_class.html"
-  },
-  {
-    "date": "21/02/2023",
-    "observer": "Iddo_3270859",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שמורת גבעת גד"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "שמורת גבעת גד": {
-        "latitude": 31.532635,
-        "longitude": 34.88851099999999
       }
     },
     "coordinates": [],
@@ -43266,28 +39888,6 @@
     "source_file": "tiuli_scraped_reports/page_25_report_1_class.html"
   },
   {
-    "date": "11/05/2022",
-    "observer": "אלחי47",
-    "title": "בוציץ סוככני",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שמורת בריכת יער, חדרה"
-    ],
-    "flowers": [
-      "בוציץ סוככני"
-    ],
-    "geocoded_locations": {
-      "שמורת בריכת יער, חדרה": {
-        "latitude": 32.412,
-        "longitude": 34.901
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_25_report_1_class.html"
-  },
-  {
     "date": "10/05/2022",
     "observer": "אלחי47",
     "title": "געדה קיפחת",
@@ -43618,28 +40218,6 @@
     "source_file": "tiuli_scraped_reports/page_25_report_1_class.html"
   },
   {
-    "date": "07/05/2022",
-    "observer": "Iddo_3270859",
-    "title": "דבורנית גדולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "Nachal Tajasim"
-    ],
-    "flowers": [
-      "דבורנית גדולה"
-    ],
-    "geocoded_locations": {
-      "Nachal Tajasim": {
-        "latitude": 31.7833527,
-        "longitude": 35.088616
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_25_report_1_class.html"
-  },
-  {
     "date": "06/05/2022",
     "observer": "assafg111",
     "title": "אירוס ארם-נהריים",
@@ -43942,50 +40520,6 @@
       "שביל המטוס סובב איתנים, איתנים": {
         "latitude": 31.778466,
         "longitude": 35.0950645
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_25_report_1_class.html"
-  },
-  {
-    "date": "21/04/2022",
-    "observer": "Iddo_3270859",
-    "title": "בן-סחלב צריפי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "אנדרטת מגילת האש"
-    ],
-    "flowers": [
-      "בן-סחלב צריפי"
-    ],
-    "geocoded_locations": {
-      "אנדרטת מגילת האש": {
-        "latitude": 31.77242820000001,
-        "longitude": 35.0442781
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_25_report_1_class.html"
-  },
-  {
-    "date": "21/04/2022",
-    "observer": "Iddo_3270859",
-    "title": "פרג אגסי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "טל שחר"
-    ],
-    "flowers": [
-      "פרג אגסי"
-    ],
-    "geocoded_locations": {
-      "טל שחר": {
-        "latitude": 31.810866428161816,
-        "longitude": 34.91136575822428
       }
     },
     "coordinates": [],
@@ -44426,72 +40960,6 @@
       "קרן ברתות": {
         "latitude": 33.0356,
         "longitude": 35.2353
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_70_report_1_class.html"
-  },
-  {
-    "date": "25/04/2016",
-    "observer": "danielk530",
-    "title": "דבורנית גדולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הר מירון"
-    ],
-    "flowers": [
-      "דבורנית גדולה"
-    ],
-    "geocoded_locations": {
-      "הר מירון": {
-        "latitude": 32.9989,
-        "longitude": 35.393
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_70_report_1_class.html"
-  },
-  {
-    "date": "25/04/2016",
-    "observer": "danielk530",
-    "title": "דבורנית גדולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הר מירון"
-    ],
-    "flowers": [
-      "דבורנית גדולה"
-    ],
-    "geocoded_locations": {
-      "הר מירון": {
-        "latitude": 32.9989,
-        "longitude": 35.393
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_70_report_1_class.html"
-  },
-  {
-    "date": "25/04/2016",
-    "observer": "danielk530",
-    "title": "דבורנית גדולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הר מירון"
-    ],
-    "flowers": [
-      "דבורנית גדולה"
-    ],
-    "geocoded_locations": {
-      "הר מירון": {
-        "latitude": 32.9989,
-        "longitude": 35.393
       }
     },
     "coordinates": [],
@@ -45213,28 +41681,6 @@
     ],
     "flowers": [
       "סתוונית היורה"
-    ],
-    "geocoded_locations": {
-      "התדהר, אור עקיבא": {
-        "latitude": 32.5238962,
-        "longitude": 34.9218541
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_45_report_1_class.html"
-  },
-  {
-    "date": "20/11/2020",
-    "observer": "Iddo_3270859",
-    "title": "נרקיס סתווי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "התדהר, אור עקיבא"
-    ],
-    "flowers": [
-      "נרקיס סתווי"
     ],
     "geocoded_locations": {
       "התדהר, אור עקיבא": {
@@ -46672,23 +43118,6 @@
   },
   {
     "date": "24/02/2013",
-    "observer": "עידו מגן",
-    "title": "רקפת מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נאות קדומים"
-    ],
-    "flowers": [
-      "רקפת מצויה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_112_report_1_class.html"
-  },
-  {
-    "date": "24/02/2013",
     "observer": "אלחי47",
     "title": "סחלב מצויר",
     "description": [
@@ -46699,57 +43128,6 @@
     ],
     "flowers": [
       "סחלב מצויר"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_112_report_1_class.html"
-  },
-  {
-    "date": "24/02/2013",
-    "observer": "אלחי47",
-    "title": "סחלב מצויר",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פרק הסלעים-שביל אדום-בעקר באחו"
-    ],
-    "flowers": [
-      "סחלב מצויר"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_112_report_1_class.html"
-  },
-  {
-    "date": "24/02/2013",
-    "observer": "אלחי47",
-    "title": "סחלב מצויר",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פרק הסלעים-שביל אדום-בעקר באחו"
-    ],
-    "flowers": [
-      "סחלב מצויר"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_112_report_1_class.html"
-  },
-  {
-    "date": "24/02/2013",
-    "observer": "אלחי47",
-    "title": "סחלב נקוד",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מעל עין אלון במפגש שביל כחול עם כביש גבעת וולפסון"
-    ],
-    "flowers": [
-      "סחלב נקוד"
     ],
     "geocoded_locations": {},
     "coordinates": [],
@@ -46917,23 +43295,6 @@
     ],
     "locations": [
       "מעלה גמלא ישוב, מפלי גמלא"
-    ],
-    "flowers": [
-      "תורמוס ההרים"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_112_report_1_class.html"
-  },
-  {
-    "date": "23/02/2013",
-    "observer": "Anat_3281140",
-    "title": "תורמוס ההרים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "גבעת המורה"
     ],
     "flowers": [
       "תורמוס ההרים"
@@ -47136,23 +43497,6 @@
     ],
     "locations": [
       "חרבת קנובה וחרבת בארית"
-    ],
-    "flowers": [
-      "שקד מצוי"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_94_report_1_class.html"
-  },
-  {
-    "date": "15/02/2014",
-    "observer": "עידו מגן",
-    "title": "שקד מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "כביש מספר 1"
     ],
     "flowers": [
       "שקד מצוי"
@@ -47589,50 +43933,6 @@
   {
     "date": "15/02/2014",
     "observer": "גדי פולק",
-    "title": "כרוב החוף",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "בין גבולות לצאלים"
-    ],
-    "flowers": [
-      "כרוב החוף"
-    ],
-    "geocoded_locations": {
-      "בין גבולות לצאלים": {
-        "latitude": 31.1973,
-        "longitude": 34.4688
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_94_report_1_class.html"
-  },
-  {
-    "date": "15/02/2014",
-    "observer": "גדי פולק",
-    "title": "לענה חד-זרעית",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "בין גבולות לצאלים"
-    ],
-    "flowers": [
-      "לענה חד-זרעית"
-    ],
-    "geocoded_locations": {
-      "בין גבולות לצאלים": {
-        "latitude": 31.1973,
-        "longitude": 34.4688
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_94_report_1_class.html"
-  },
-  {
-    "date": "15/02/2014",
-    "observer": "גדי פולק",
     "title": "מנתור המדבר",
     "description": [
       ""
@@ -47642,50 +43942,6 @@
     ],
     "flowers": [
       "מנתור המדבר"
-    ],
-    "geocoded_locations": {
-      "בין גבולות לצאלים": {
-        "latitude": 31.1973,
-        "longitude": 34.4688
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_94_report_1_class.html"
-  },
-  {
-    "date": "15/02/2014",
-    "observer": "גדי פולק",
-    "title": "אמיך קוצני",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "בין גבולות לצאלים"
-    ],
-    "flowers": [
-      "אמיך קוצני"
-    ],
-    "geocoded_locations": {
-      "בין גבולות לצאלים": {
-        "latitude": 31.1973,
-        "longitude": 34.4688
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_94_report_1_class.html"
-  },
-  {
-    "date": "15/02/2014",
-    "observer": "גדי פולק",
-    "title": "ציפורני-חתול מצויות",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "בין גבולות לצאלים"
-    ],
-    "flowers": [
-      "ציפורני-חתול מצויות"
     ],
     "geocoded_locations": {
       "בין גבולות לצאלים": {
@@ -47752,50 +44008,6 @@
     ],
     "flowers": [
       "קרדה דרומית"
-    ],
-    "geocoded_locations": {
-      "בין גבולות לצאלים": {
-        "latitude": 31.1973,
-        "longitude": 34.4688
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_94_report_1_class.html"
-  },
-  {
-    "date": "15/02/2014",
-    "observer": "גדי פולק",
-    "title": "חורשף צהוב",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "בין גבולות לצאלים"
-    ],
-    "flowers": [
-      "חורשף צהוב"
-    ],
-    "geocoded_locations": {
-      "בין גבולות לצאלים": {
-        "latitude": 31.1973,
-        "longitude": 34.4688
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_94_report_1_class.html"
-  },
-  {
-    "date": "15/02/2014",
-    "observer": "גדי פולק",
-    "title": "מקור-חסידה מפוצל",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "בין גבולות לצאלים"
-    ],
-    "flowers": [
-      "מקור-חסידה מפוצל"
     ],
     "geocoded_locations": {
       "בין גבולות לצאלים": {
@@ -47919,50 +44131,6 @@
   {
     "date": "15/02/2014",
     "observer": "גדי פולק",
-    "title": "אירוס הנגב",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "בין גבולות לצאלים"
-    ],
-    "flowers": [
-      "אירוס הנגב"
-    ],
-    "geocoded_locations": {
-      "בין גבולות לצאלים": {
-        "latitude": 31.1973,
-        "longitude": 34.4688
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_94_report_1_class.html"
-  },
-  {
-    "date": "15/02/2014",
-    "observer": "גדי פולק",
-    "title": "קזוח עקום",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "בין גבולות לצאלים"
-    ],
-    "flowers": [
-      "קזוח עקום"
-    ],
-    "geocoded_locations": {
-      "בין גבולות לצאלים": {
-        "latitude": 31.1973,
-        "longitude": 34.4688
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_94_report_1_class.html"
-  },
-  {
-    "date": "15/02/2014",
-    "observer": "גדי פולק",
     "title": "רותם המדבר",
     "description": [
       ""
@@ -48029,28 +44197,6 @@
   {
     "date": "15/02/2014",
     "observer": "גדי פולק",
-    "title": "סתוונית הנגב",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "בין גבולות לצאלים"
-    ],
-    "flowers": [
-      "סתוונית הנגב"
-    ],
-    "geocoded_locations": {
-      "בין גבולות לצאלים": {
-        "latitude": 31.1993,
-        "longitude": 34.487
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_94_report_1_class.html"
-  },
-  {
-    "date": "15/02/2014",
-    "observer": "גדי פולק",
     "title": "נץ-חלב דק-עלים",
     "description": [
       ""
@@ -48060,28 +44206,6 @@
     ],
     "flowers": [
       "נץ-חלב דק-עלים"
-    ],
-    "geocoded_locations": {
-      "בין גבולות לצאלים": {
-        "latitude": 31.1993,
-        "longitude": 34.487
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_94_report_1_class.html"
-  },
-  {
-    "date": "15/02/2014",
-    "observer": "גדי פולק",
-    "title": "זמזומית איג",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "בין גבולות לצאלים"
-    ],
-    "flowers": [
-      "זמזומית איג"
     ],
     "geocoded_locations": {
       "בין גבולות לצאלים": {
@@ -48270,138 +44394,6 @@
   },
   {
     "date": "03/03/2017",
-    "observer": "עידו מגן",
-    "title": "רקפת מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חניון גרשון וחנה הדס בפארק עצמות ארה\"ב"
-    ],
-    "flowers": [
-      "רקפת מצויה"
-    ],
-    "geocoded_locations": {
-      "חניון גרשון וחנה הדס בפארק עצמות ארה\"ב": {
-        "latitude": 31.7458,
-        "longitude": 35.0331
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_65_report_1_class.html"
-  },
-  {
-    "date": "03/03/2017",
-    "observer": "עידו מגן",
-    "title": "עירית גדולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חניון גרשון וחנה הדס בפארק עצמות ארה\"ב"
-    ],
-    "flowers": [
-      "עירית גדולה"
-    ],
-    "geocoded_locations": {
-      "חניון גרשון וחנה הדס בפארק עצמות ארה\"ב": {
-        "latitude": 31.7458,
-        "longitude": 35.0331
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_65_report_1_class.html"
-  },
-  {
-    "date": "03/03/2017",
-    "observer": "עידו מגן",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חניון גרשון וחנה הדס בפארק עצמות ארה\"ב"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "חניון גרשון וחנה הדס בפארק עצמות ארה\"ב": {
-        "latitude": 31.7458,
-        "longitude": 35.0331
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_65_report_1_class.html"
-  },
-  {
-    "date": "03/03/2017",
-    "observer": "עידו מגן",
-    "title": "עירית גדולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שביל הקיסר ליד חרבת חנות"
-    ],
-    "flowers": [
-      "עירית גדולה"
-    ],
-    "geocoded_locations": {
-      "שביל הקיסר ליד חרבת חנות": {
-        "latitude": 31.7119,
-        "longitude": 35.046
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_65_report_1_class.html"
-  },
-  {
-    "date": "03/03/2017",
-    "observer": "עידו מגן",
-    "title": "רקפת מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שביל הקיסר ליד חרבת חנות"
-    ],
-    "flowers": [
-      "רקפת מצויה"
-    ],
-    "geocoded_locations": {
-      "שביל הקיסר ליד חרבת חנות": {
-        "latitude": 31.7119,
-        "longitude": 35.046
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_65_report_1_class.html"
-  },
-  {
-    "date": "03/03/2017",
-    "observer": "עידו מגן",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שביל הקיסר ליד חרבת חנות"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "שביל הקיסר ליד חרבת חנות": {
-        "latitude": 31.7119,
-        "longitude": 35.046
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_65_report_1_class.html"
-  },
-  {
-    "date": "03/03/2017",
     "observer": "איריס_בר",
     "title": "זמזומית המדבר",
     "description": [
@@ -48417,28 +44409,6 @@
       "בורות לוץ": {
         "latitude": 30.632,
         "longitude": 34.7587
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_65_report_1_class.html"
-  },
-  {
-    "date": "03/03/2017",
-    "observer": "איריס_בר",
-    "title": "זמזומית המדבר",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "בורות לוץ"
-    ],
-    "flowers": [
-      "זמזומית המדבר"
-    ],
-    "geocoded_locations": {
-      "בורות לוץ": {
-        "latitude": 30.567,
-        "longitude": 34.6481
       }
     },
     "coordinates": [],
@@ -48769,28 +44739,6 @@
       "שמורת טבע גמלא": {
         "latitude": 32.9057,
         "longitude": 35.7484
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_65_report_1_class.html"
-  },
-  {
-    "date": "25/02/2017",
-    "observer": "דרורית.כ",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "אחו נוב"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "אחו נוב": {
-        "latitude": 32.8347,
-        "longitude": 35.7979
       }
     },
     "coordinates": [],
@@ -51453,23 +47401,6 @@
   {
     "date": "01/10/2008",
     "observer": "המטייל האנונימי",
-    "title": "חבצלת קטנת-פרחים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חיפה נחל איזוב ליד מבנים נטושים, האכסניה"
-    ],
-    "flowers": [
-      "חבצלת קטנת-פרחים"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_170_report_1_class.html"
-  },
-  {
-    "date": "01/10/2008",
-    "observer": "המטייל האנונימי",
     "title": "סתוונית בכירה",
     "description": [
       ""
@@ -51621,23 +47552,6 @@
     "source_file": "tiuli_scraped_reports/page_170_report_1_class.html"
   },
   {
-    "date": "20/09/2008",
-    "observer": "המטייל האנונימי",
-    "title": "חצב מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "צומת יד מרדכי"
-    ],
-    "flowers": [
-      "חצב מצוי"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_170_report_1_class.html"
-  },
-  {
     "date": "18/09/2008",
     "observer": "המטייל האנונימי",
     "title": "חצב מצוי",
@@ -51748,23 +47662,6 @@
     ],
     "locations": [
       "גבעות סביב ק.דליה"
-    ],
-    "flowers": [
-      "חצב מצוי"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_170_report_1_class.html"
-  },
-  {
-    "date": "22/08/2008",
-    "observer": "המטייל האנונימי",
-    "title": "חצב מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "גבעה צפון לדליה ועוד"
     ],
     "flowers": [
       "חצב מצוי"
@@ -52080,40 +47977,6 @@
     "source_file": "tiuli_scraped_reports/page_177_report_1_class.html"
   },
   {
-    "date": "03/02/2008",
-    "observer": "המטייל האנונימי",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער חרובית"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_177_report_1_class.html"
-  },
-  {
-    "date": "03/02/2008",
-    "observer": "המטייל האנונימי",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "עמק מהר\"ל"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_177_report_1_class.html"
-  },
-  {
     "date": "02/02/2008",
     "observer": "המטייל האנונימי",
     "title": "שמשון הדור",
@@ -52337,23 +48200,6 @@
   {
     "date": "02/02/2008",
     "observer": "המטייל האנונימי",
-    "title": "אירוס ארץ-ישראלי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "להבים"
-    ],
-    "flowers": [
-      "אירוס ארץ-ישראלי"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_177_report_1_class.html"
-  },
-  {
-    "date": "02/02/2008",
-    "observer": "המטייל האנונימי",
     "title": "כלנית מצויה",
     "description": [
       ""
@@ -52363,23 +48209,6 @@
     ],
     "flowers": [
       "כלנית מצויה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_177_report_1_class.html"
-  },
-  {
-    "date": "02/02/2008",
-    "observer": "המטייל האנונימי",
-    "title": "אירוס ארץ-ישראלי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער חרובית"
-    ],
-    "flowers": [
-      "אירוס ארץ-ישראלי"
     ],
     "geocoded_locations": {},
     "coordinates": [],
@@ -53598,28 +49427,6 @@
   {
     "date": "21/02/2013",
     "observer": "גדי פולק",
-    "title": "שיבולת-שועל נפוצה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "כיסופים ליד בית הקברות"
-    ],
-    "flowers": [
-      "שיבולת-שועל נפוצה"
-    ],
-    "geocoded_locations": {
-      "כיסופים ליד בית הקברות": {
-        "latitude": 31.3733,
-        "longitude": 34.4019
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_113_report_1_class.html"
-  },
-  {
-    "date": "21/02/2013",
-    "observer": "גדי פולק",
     "title": "כלנית מצויה",
     "description": [
       ""
@@ -53629,28 +49436,6 @@
     ],
     "flowers": [
       "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "דרך הבשור ליד סוללת הרכבת": {
-        "latitude": 31.3034,
-        "longitude": 34.4802
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_113_report_1_class.html"
-  },
-  {
-    "date": "21/02/2013",
-    "observer": "גדי פולק",
-    "title": "ניסנית דו-קרנית",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "דרך הבשור ליד סוללת הרכבת"
-    ],
-    "flowers": [
-      "ניסנית דו-קרנית"
     ],
     "geocoded_locations": {
       "דרך הבשור ליד סוללת הרכבת": {
@@ -53695,28 +49480,6 @@
     ],
     "flowers": [
       "מנתור המדבר"
-    ],
-    "geocoded_locations": {
-      "דרך הבשור ליד סוללת הרכבת": {
-        "latitude": 31.3034,
-        "longitude": 34.4802
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_113_report_1_class.html"
-  },
-  {
-    "date": "21/02/2013",
-    "observer": "גדי פולק",
-    "title": "אטד אירופי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "דרך הבשור ליד סוללת הרכבת"
-    ],
-    "flowers": [
-      "אטד אירופי"
     ],
     "geocoded_locations": {
       "דרך הבשור ליד סוללת הרכבת": {
@@ -55248,28 +51011,6 @@
   {
     "date": "19/03/2022",
     "observer": "Iddo_3270859",
-    "title": "סחלב פרפרני",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "רמת הנדיב"
-    ],
-    "flowers": [
-      "סחלב פרפרני"
-    ],
-    "geocoded_locations": {
-      "רמת הנדיב": {
-        "latitude": 32.547972,
-        "longitude": 34.944247
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_28_report_1_class.html"
-  },
-  {
-    "date": "19/03/2022",
-    "observer": "Iddo_3270859",
     "title": "רקפת מצויה",
     "description": [
       ""
@@ -55279,28 +51020,6 @@
     ],
     "flowers": [
       "רקפת מצויה"
-    ],
-    "geocoded_locations": {
-      "רמת הנדיב": {
-        "latitude": 32.547972,
-        "longitude": 34.944247
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_28_report_1_class.html"
-  },
-  {
-    "date": "19/03/2022",
-    "observer": "Iddo_3270859",
-    "title": "נורית אסיה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "רמת הנדיב"
-    ],
-    "flowers": [
-      "נורית אסיה"
     ],
     "geocoded_locations": {
       "רמת הנדיב": {
@@ -56282,50 +52001,6 @@
   {
     "date": "22/04/2011",
     "observer": "גדי פולק",
-    "title": "מוצית קוצנית",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער לביא"
-    ],
-    "flowers": [
-      "מוצית קוצנית"
-    ],
-    "geocoded_locations": {
-      "יער לביא": {
-        "latitude": 32.6073,
-        "longitude": 35.4117
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_134_report_1_class.html"
-  },
-  {
-    "date": "22/04/2011",
-    "observer": "גדי פולק",
-    "title": "נוצנית כדורית",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער לביא"
-    ],
-    "flowers": [
-      "נוצנית כדורית"
-    ],
-    "geocoded_locations": {
-      "יער לביא": {
-        "latitude": 32.6073,
-        "longitude": 35.4117
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_134_report_1_class.html"
-  },
-  {
-    "date": "22/04/2011",
-    "observer": "גדי פולק",
     "title": "סירה קוצנית",
     "description": [
       ""
@@ -56379,28 +52054,6 @@
     ],
     "flowers": [
       "עיריוני צהוב"
-    ],
-    "geocoded_locations": {
-      "יער לביא": {
-        "latitude": 32.6073,
-        "longitude": 35.4117
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_134_report_1_class.html"
-  },
-  {
-    "date": "22/04/2011",
-    "observer": "גדי פולק",
-    "title": "פשתה שעירה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער לביא"
-    ],
-    "flowers": [
-      "פשתה שעירה"
     ],
     "geocoded_locations": {
       "יער לביא": {
@@ -56643,28 +52296,6 @@
     ],
     "flowers": [
       "ברומית אזמלנית"
-    ],
-    "geocoded_locations": {
-      "מעלה אלישע": {
-        "latitude": 32.5982,
-        "longitude": 35.5176
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_134_report_1_class.html"
-  },
-  {
-    "date": "22/04/2011",
-    "observer": "גדי פולק",
-    "title": "ברקן סורי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מעלה אלישע"
-    ],
-    "flowers": [
-      "ברקן סורי"
     ],
     "geocoded_locations": {
       "מעלה אלישע": {
@@ -57418,28 +53049,6 @@
       "מנחת מגידו": {
         "latitude": 31.9582,
         "longitude": 34.7943
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_82_report_1_class.html"
-  },
-  {
-    "date": "03/01/2015",
-    "observer": "עידו מגן",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מנחת מגידו"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "מנחת מגידו": {
-        "latitude": 32.5966,
-        "longitude": 35.2436
       }
     },
     "coordinates": [],
@@ -58460,28 +54069,6 @@
   {
     "date": "10/02/2023",
     "observer": "Iddo_3270859",
-    "title": "רקפת מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער הקדושים"
-    ],
-    "flowers": [
-      "רקפת מצויה"
-    ],
-    "geocoded_locations": {
-      "יער הקדושים": {
-        "latitude": 31.780806,
-        "longitude": 35.061326
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_19_report_1_class.html"
-  },
-  {
-    "date": "10/02/2023",
-    "observer": "Iddo_3270859",
     "title": "כלנית מצויה",
     "description": [
       ""
@@ -58496,50 +54083,6 @@
       "תל בית שמש, בית שמש": {
         "latitude": 31.75030299999999,
         "longitude": 34.975495
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_19_report_1_class.html"
-  },
-  {
-    "date": "10/02/2023",
-    "observer": "Iddo_3270859",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער הקדושים"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "יער הקדושים": {
-        "latitude": 31.780806,
-        "longitude": 35.061326
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_19_report_1_class.html"
-  },
-  {
-    "date": "10/02/2023",
-    "observer": "Iddo_3270859",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "עין מסלה"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "עין מסלה": {
-        "latitude": 31.8097222,
-        "longitude": 35.0133333
       }
     },
     "coordinates": [],
@@ -59068,28 +54611,6 @@
       "תל חדיד": {
         "latitude": 31.963534,
         "longitude": 34.95203
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_19_report_1_class.html"
-  },
-  {
-    "date": "27/01/2023",
-    "observer": "Iddo_3270859",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק שוהם, צורן, שוהם"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "פארק שוהם, צורן, שוהם": {
-        "latitude": 31.9888038,
-        "longitude": 34.9481468
       }
     },
     "coordinates": [],
@@ -59887,28 +55408,6 @@
   {
     "date": "02/11/2013",
     "observer": "גדי פולק",
-    "title": "אלת המסטיק",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מצפור לוקי יער המכללות ליד נווה אילן"
-    ],
-    "flowers": [
-      "אלת המסטיק"
-    ],
-    "geocoded_locations": {
-      "מצפור לוקי יער המכללות ליד נווה אילן": {
-        "latitude": 31.8108,
-        "longitude": 35.0715
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_101_report_1_class.html"
-  },
-  {
-    "date": "02/11/2013",
-    "observer": "גדי פולק",
     "title": "שרביטן מצוי",
     "description": [
       ""
@@ -59918,28 +55417,6 @@
     ],
     "flowers": [
       "שרביטן מצוי"
-    ],
-    "geocoded_locations": {
-      "מצפור לוקי יער המכללות ליד נווה אילן": {
-        "latitude": 31.8108,
-        "longitude": 35.0715
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_101_report_1_class.html"
-  },
-  {
-    "date": "02/11/2013",
-    "observer": "גדי פולק",
-    "title": "טיון דביק",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מצפור לוקי יער המכללות ליד נווה אילן"
-    ],
-    "flowers": [
-      "טיון דביק"
     ],
     "geocoded_locations": {
       "מצפור לוקי יער המכללות ליד נווה אילן": {
@@ -60011,116 +55488,6 @@
       "מצפור לוקי יער המכללות ליד נווה אילן": {
         "latitude": 31.8108,
         "longitude": 35.0715
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_101_report_1_class.html"
-  },
-  {
-    "date": "02/11/2013",
-    "observer": "גדי פולק",
-    "title": "קיסוסית קוצנית",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מצפור לוקי יער המכללות ליד נווה אילן"
-    ],
-    "flowers": [
-      "קיסוסית קוצנית"
-    ],
-    "geocoded_locations": {
-      "מצפור לוקי יער המכללות ליד נווה אילן": {
-        "latitude": 31.8108,
-        "longitude": 35.0715
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_101_report_1_class.html"
-  },
-  {
-    "date": "02/11/2013",
-    "observer": "גדי פולק",
-    "title": "גזר קיפח",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מצפור לוקי יער המכללות ליד נווה אילן"
-    ],
-    "flowers": [
-      "גזר קיפח"
-    ],
-    "geocoded_locations": {
-      "מצפור לוקי יער המכללות ליד נווה אילן": {
-        "latitude": 31.8108,
-        "longitude": 35.0715
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_101_report_1_class.html"
-  },
-  {
-    "date": "02/11/2013",
-    "observer": "גדי פולק",
-    "title": "שומר פשוט",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חורבת מצדית יער המכללות נווה אילן"
-    ],
-    "flowers": [
-      "שומר פשוט"
-    ],
-    "geocoded_locations": {
-      "חורבת מצדית יער המכללות נווה אילן": {
-        "latitude": 31.8165,
-        "longitude": 35.0548
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_101_report_1_class.html"
-  },
-  {
-    "date": "02/11/2013",
-    "observer": "גדי פולק",
-    "title": "אלה ארץ-ישראלית",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חורבת מצדית יער המכללות נווה אילן"
-    ],
-    "flowers": [
-      "אלה ארץ-ישראלית"
-    ],
-    "geocoded_locations": {
-      "חורבת מצדית יער המכללות נווה אילן": {
-        "latitude": 31.8165,
-        "longitude": 35.0548
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_101_report_1_class.html"
-  },
-  {
-    "date": "02/11/2013",
-    "observer": "גדי פולק",
-    "title": "אשחר ארץ-ישראלי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חורבת מצדית יער המכללות נווה אילן"
-    ],
-    "flowers": [
-      "אשחר ארץ-ישראלי"
-    ],
-    "geocoded_locations": {
-      "חורבת מצדית יער המכללות נווה אילן": {
-        "latitude": 31.8165,
-        "longitude": 35.0548
       }
     },
     "coordinates": [],
@@ -61209,50 +56576,6 @@
   {
     "date": "04/06/2013",
     "observer": "גדי פולק",
-    "title": "קנה מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "תעלה 40 דרומית מזרחית לעין המפרץ; הצומח עבר כיסוח"
-    ],
-    "flowers": [
-      "קנה מצוי"
-    ],
-    "geocoded_locations": {
-      "תעלה 40 דרומית מזרחית לעין המפרץ; הצומח עבר כיסוח": {
-        "latitude": 32.9175,
-        "longitude": 35.1021
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_103_report_1_class.html"
-  },
-  {
-    "date": "04/06/2013",
-    "observer": "גדי פולק",
-    "title": "חנק מחודד",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "תעלה 40 דרומית מזרחית לעין המפרץ; הצומח עבר כיסוח"
-    ],
-    "flowers": [
-      "חנק מחודד"
-    ],
-    "geocoded_locations": {
-      "תעלה 40 דרומית מזרחית לעין המפרץ; הצומח עבר כיסוח": {
-        "latitude": 32.9175,
-        "longitude": 35.1021
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_103_report_1_class.html"
-  },
-  {
-    "date": "04/06/2013",
-    "observer": "גדי פולק",
     "title": "לחך אזמלני",
     "description": [
       ""
@@ -61350,28 +56673,6 @@
     ],
     "flowers": [
       "מרגנית השדה"
-    ],
-    "geocoded_locations": {
-      "תעלה 40 דרומית מזרחית לעין המפרץ; הצומח עבר כיסוח": {
-        "latitude": 32.9175,
-        "longitude": 35.1021
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_103_report_1_class.html"
-  },
-  {
-    "date": "04/06/2013",
-    "observer": "גדי פולק",
-    "title": "ערבז משובל",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "תעלה 40 דרומית מזרחית לעין המפרץ; הצומח עבר כיסוח"
-    ],
-    "flowers": [
-      "ערבז משובל"
     ],
     "geocoded_locations": {
       "תעלה 40 דרומית מזרחית לעין המפרץ; הצומח עבר כיסוח": {
@@ -61495,28 +56796,6 @@
   {
     "date": "04/06/2013",
     "observer": "גדי פולק",
-    "title": "קנה מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "בדרך לאורך הנעמן ובתעלת הנעמן צפונה לאפיק הישן (מצפון לאקליפטוס)"
-    ],
-    "flowers": [
-      "קנה מצוי"
-    ],
-    "geocoded_locations": {
-      "בדרך לאורך הנעמן ובתעלת הנעמן צפונה לאפיק הישן (מצפון לאקליפטוס)": {
-        "latitude": 32.9047,
-        "longitude": 35.1031
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_103_report_1_class.html"
-  },
-  {
-    "date": "04/06/2013",
-    "observer": "גדי פולק",
     "title": "גדילן מצוי",
     "description": [
       ""
@@ -61539,28 +56818,6 @@
   {
     "date": "04/06/2013",
     "observer": "גדי פולק",
-    "title": "חוח עקוד",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "בדרך לאורך הנעמן ובתעלת הנעמן צפונה לאפיק הישן (מצפון לאקליפטוס)"
-    ],
-    "flowers": [
-      "חוח עקוד"
-    ],
-    "geocoded_locations": {
-      "בדרך לאורך הנעמן ובתעלת הנעמן צפונה לאפיק הישן (מצפון לאקליפטוס)": {
-        "latitude": 32.9047,
-        "longitude": 35.1031
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_103_report_1_class.html"
-  },
-  {
-    "date": "04/06/2013",
-    "observer": "גדי פולק",
     "title": "ירבוז מופשל",
     "description": [
       ""
@@ -61570,28 +56827,6 @@
     ],
     "flowers": [
       "ירבוז מופשל"
-    ],
-    "geocoded_locations": {
-      "בדרך לאורך הנעמן ובתעלת הנעמן צפונה לאפיק הישן (מצפון לאקליפטוס)": {
-        "latitude": 32.9047,
-        "longitude": 35.1031
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_103_report_1_class.html"
-  },
-  {
-    "date": "04/06/2013",
-    "observer": "גדי פולק",
-    "title": "חנק מחודד",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "בדרך לאורך הנעמן ובתעלת הנעמן צפונה לאפיק הישן (מצפון לאקליפטוס)"
-    ],
-    "flowers": [
-      "חנק מחודד"
     ],
     "geocoded_locations": {
       "בדרך לאורך הנעמן ובתעלת הנעמן צפונה לאפיק הישן (מצפון לאקליפטוס)": {
@@ -61847,72 +57082,6 @@
   {
     "date": "04/06/2013",
     "observer": "גדי פולק",
-    "title": "דרדר הקורים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מלחת הנעמן - קטע חולי קרוב לגשר רמז"
-    ],
-    "flowers": [
-      "דרדר הקורים"
-    ],
-    "geocoded_locations": {
-      "מלחת הנעמן - קטע חולי קרוב לגשר רמז": {
-        "latitude": 32.9096,
-        "longitude": 35.0878
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_103_report_1_class.html"
-  },
-  {
-    "date": "04/06/2013",
-    "observer": "גדי פולק",
-    "title": "שעורה נימית",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מלחת הנעמן מצפון לתוואי רכבת עכו - כרמיאל"
-    ],
-    "flowers": [
-      "שעורה נימית"
-    ],
-    "geocoded_locations": {
-      "מלחת הנעמן מצפון לתוואי רכבת עכו - כרמיאל": {
-        "latitude": 32.912,
-        "longitude": 35.087
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_103_report_1_class.html"
-  },
-  {
-    "date": "04/06/2013",
-    "observer": "גדי פולק",
-    "title": "סמר חד",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מלחת הנעמן מצפון לתוואי רכבת עכו - כרמיאל"
-    ],
-    "flowers": [
-      "סמר חד"
-    ],
-    "geocoded_locations": {
-      "מלחת הנעמן מצפון לתוואי רכבת עכו - כרמיאל": {
-        "latitude": 32.912,
-        "longitude": 35.087
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_103_report_1_class.html"
-  },
-  {
-    "date": "04/06/2013",
-    "observer": "גדי פולק",
     "title": "בן-טיון בשרני",
     "description": [
       ""
@@ -61922,50 +57091,6 @@
     ],
     "flowers": [
       "בן-טיון בשרני"
-    ],
-    "geocoded_locations": {
-      "מלחת הנעמן מצפון לתוואי רכבת עכו - כרמיאל": {
-        "latitude": 32.912,
-        "longitude": 35.087
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_103_report_1_class.html"
-  },
-  {
-    "date": "04/06/2013",
-    "observer": "גדי פולק",
-    "title": "מלוח רגלני",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מלחת הנעמן מצפון לתוואי רכבת עכו - כרמיאל"
-    ],
-    "flowers": [
-      "מלוח רגלני"
-    ],
-    "geocoded_locations": {
-      "מלחת הנעמן מצפון לתוואי רכבת עכו - כרמיאל": {
-        "latitude": 32.912,
-        "longitude": 35.087
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_103_report_1_class.html"
-  },
-  {
-    "date": "04/06/2013",
-    "observer": "גדי פולק",
-    "title": "דרדר הקורים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מלחת הנעמן מצפון לתוואי רכבת עכו - כרמיאל"
-    ],
-    "flowers": [
-      "דרדר הקורים"
     ],
     "geocoded_locations": {
       "מלחת הנעמן מצפון לתוואי רכבת עכו - כרמיאל": {
@@ -62449,23 +57574,6 @@
     ],
     "locations": [
       "כביש 672"
-    ],
-    "flowers": [
-      "אגס סורי"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_122_report_1_class.html"
-  },
-  {
-    "date": "12/03/2012",
-    "observer": "המטייל האנונימי",
-    "title": "אגס סורי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חיבור נחל חיק ונחל אורן"
     ],
     "flowers": [
       "אגס סורי"
@@ -64157,28 +59265,6 @@
     "source_file": "tiuli_scraped_reports/page_11_report_1_class.html"
   },
   {
-    "date": "25/05/2023",
-    "observer": "אלחי47",
-    "title": "בן-חורש רחב-עלים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "תל קצעה, בוקעאתא"
-    ],
-    "flowers": [
-      "בן-חורש רחב-עלים"
-    ],
-    "geocoded_locations": {
-      "תל קצעה, בוקעאתא": {
-        "latitude": 33.213,
-        "longitude": 35.759
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_11_report_1_class.html"
-  },
-  {
     "date": "20/05/2023",
     "observer": "Eyal Cochva_4209233",
     "title": "כנפון זהוב",
@@ -65643,40 +60729,6 @@
   {
     "date": "06/03/2010",
     "observer": "המטייל האנונימי",
-    "title": "דרדר כחול",
-    "description": [
-      ""
-    ],
-    "locations": [
-      " שמורת  הטבע  רמת  הנדיב. ע''י  זכרון  יעקב"
-    ],
-    "flowers": [
-      "דרדר כחול"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_150_report_1_class.html"
-  },
-  {
-    "date": "06/03/2010",
-    "observer": "המטייל האנונימי",
-    "title": "צהרון מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      " שמורת  הטבע  רמת  הנדיב, ע''י  זכרון  יעקב."
-    ],
-    "flowers": [
-      "צהרון מצוי"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_150_report_1_class.html"
-  },
-  {
-    "date": "06/03/2010",
-    "observer": "המטייל האנונימי",
     "title": "נורית אסיה",
     "description": [
       ""
@@ -66141,28 +61193,6 @@
   {
     "date": "12/11/2019",
     "observer": "עידו מגן",
-    "title": "סתוונית היורה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חורבת חנות"
-    ],
-    "flowers": [
-      "סתוונית היורה"
-    ],
-    "geocoded_locations": {
-      "חורבת חנות": {
-        "latitude": 31.711655,
-        "longitude": 35.04688799999997
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_52_report_1_class.html"
-  },
-  {
-    "date": "12/11/2019",
-    "observer": "עידו מגן",
     "title": "נרקיס מצוי",
     "description": [
       ""
@@ -66243,50 +61273,6 @@
       "31.7389597,35.0740643": {
         "latitude": 31.7389597,
         "longitude": 35.0740643
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_52_report_1_class.html"
-  },
-  {
-    "date": "02/11/2019",
-    "observer": "עידו מגן",
-    "title": "סתוונית היורה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "עינות בקר"
-    ],
-    "flowers": [
-      "סתוונית היורה"
-    ],
-    "geocoded_locations": {
-      "עינות בקר": {
-        "latitude": 31.7808333,
-        "longitude": 35.055555599999934
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_52_report_1_class.html"
-  },
-  {
-    "date": "02/11/2019",
-    "observer": "עידו מגן",
-    "title": "סתוונית היורה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "עינות בקר"
-    ],
-    "flowers": [
-      "סתוונית היורה"
-    ],
-    "geocoded_locations": {
-      "עינות בקר": {
-        "latitude": 31.7808333,
-        "longitude": 35.055555599999934
       }
     },
     "coordinates": [],
@@ -66645,28 +61631,6 @@
     "source_file": "tiuli_scraped_reports/page_52_report_1_class.html"
   },
   {
-    "date": "24/05/2019",
-    "observer": "אלחי47",
-    "title": "נזמית מקווקוות",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הר חרמון"
-    ],
-    "flowers": [
-      "נזמית מקווקוות"
-    ],
-    "geocoded_locations": {
-      "הר חרמון": {
-        "latitude": 801079.0,
-        "longitude": 273613.0
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_52_report_1_class.html"
-  },
-  {
     "date": "23/05/2019",
     "observer": "אלחי47",
     "title": "אבובית מקורקפת",
@@ -66823,28 +61787,6 @@
   {
     "date": "02/03/2023",
     "observer": "אלחי47",
-    "title": "אירוס הביצות",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "עמק השלום, יוקנעם עילית"
-    ],
-    "flowers": [
-      "אירוס הביצות"
-    ],
-    "geocoded_locations": {
-      "עמק השלום, יוקנעם עילית": {
-        "latitude": 32.641,
-        "longitude": 35.102
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_17_report_1_class.html"
-  },
-  {
-    "date": "02/03/2023",
-    "observer": "אלחי47",
     "title": "צהרון מצוי",
     "description": [
       ""
@@ -66969,28 +61911,6 @@
       "יער ברזיל": {
         "latitude": 31.939124469484625,
         "longitude": 34.99267230459482
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_17_report_1_class.html"
-  },
-  {
-    "date": "01/03/2023",
-    "observer": "מטייל_4542",
-    "title": "צהרון מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "קברות המכבים, מבוא מודיעים"
-    ],
-    "flowers": [
-      "צהרון מצוי"
-    ],
-    "geocoded_locations": {
-      "קברות המכבים, מבוא מודיעים": {
-        "latitude": 31.93937334220963,
-        "longitude": 34.99248389194949
       }
     },
     "coordinates": [],
@@ -67328,28 +62248,6 @@
   },
   {
     "date": "26/02/2023",
-    "observer": "Iddo_3270859",
-    "title": "שקד מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "ליפתא"
-    ],
-    "flowers": [
-      "שקד מצוי"
-    ],
-    "geocoded_locations": {
-      "ליפתא": {
-        "latitude": 31.795278,
-        "longitude": 35.196389
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_17_report_1_class.html"
-  },
-  {
-    "date": "26/02/2023",
     "observer": "אלחי47",
     "title": "אירוס טוביה",
     "description": [
@@ -67431,28 +62329,6 @@
       "חמדת": {
         "latitude": 32.25139133031786,
         "longitude": 35.52373397213081
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_17_report_1_class.html"
-  },
-  {
-    "date": "25/02/2023",
-    "observer": "דני17",
-    "title": "אירוס הגלבוע",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "ישוב חמדת שבשומרון"
-    ],
-    "flowers": [
-      "אירוס הגלבוע"
-    ],
-    "geocoded_locations": {
-      "ישוב חמדת שבשומרון": {
-        "latitude": 32.25200234165412,
-        "longitude": 35.52441242750889
       }
     },
     "coordinates": [],
@@ -67673,72 +62549,6 @@
       "1, ירושלים": {
         "latitude": 31.837514066241916,
         "longitude": 34.99607343526947
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_17_report_1_class.html"
-  },
-  {
-    "date": "24/02/2023",
-    "observer": "Iddo_3270859",
-    "title": "שקד מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק איילון קנדה"
-    ],
-    "flowers": [
-      "שקד מצוי"
-    ],
-    "geocoded_locations": {
-      "פארק איילון קנדה": {
-        "latitude": 31.850812105288554,
-        "longitude": 34.99285983163507
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_17_report_1_class.html"
-  },
-  {
-    "date": "24/02/2023",
-    "observer": "Iddo_3270859",
-    "title": "שקד מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מבוא חורון"
-    ],
-    "flowers": [
-      "שקד מצוי"
-    ],
-    "geocoded_locations": {
-      "מבוא חורון": {
-        "latitude": 31.850634541443778,
-        "longitude": 35.03454682484946
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_17_report_1_class.html"
-  },
-  {
-    "date": "24/02/2023",
-    "observer": "Iddo_3270859",
-    "title": "שקד מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מיני ישראל"
-    ],
-    "flowers": [
-      "שקד מצוי"
-    ],
-    "geocoded_locations": {
-      "מיני ישראל": {
-        "latitude": 31.8421649,
-        "longitude": 34.9690158
       }
     },
     "coordinates": [],
@@ -68077,28 +62887,6 @@
   {
     "date": "04/03/2021",
     "observer": "לבון רחל  קולומבוסית",
-    "title": "צבעוני ההרים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער ראש העין, ראש העין"
-    ],
-    "flowers": [
-      "צבעוני ההרים"
-    ],
-    "geocoded_locations": {
-      "יער ראש העין, ראש העין": {
-        "latitude": 32.093709,
-        "longitude": 34.9729249
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_39_report_1_class.html"
-  },
-  {
-    "date": "04/03/2021",
-    "observer": "לבון רחל  קולומבוסית",
     "title": "שום תל-אביב",
     "description": [
       ""
@@ -68157,28 +62945,6 @@
       "גבעת המורה, עפולה": {
         "latitude": 32.63017529522996,
         "longitude": 35.330048341935374
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_39_report_1_class.html"
-  },
-  {
-    "date": "04/03/2021",
-    "observer": "מ.פ 1967",
-    "title": "אירוס נצרתי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שמורת גבעת המורה, עפולה"
-    ],
-    "flowers": [
-      "אירוס נצרתי"
-    ],
-    "geocoded_locations": {
-      "שמורת גבעת המורה, עפולה": {
-        "latitude": 32.62173486887954,
-        "longitude": 35.36331166468927
       }
     },
     "coordinates": [],
@@ -68715,28 +63481,6 @@
   {
     "date": "26/02/2021",
     "observer": "Iddo_3270859",
-    "title": "שקד מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "עמק האלה"
-    ],
-    "flowers": [
-      "שקד מצוי"
-    ],
-    "geocoded_locations": {
-      "עמק האלה": {
-        "latitude": 31.6882277,
-        "longitude": 34.9495982
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_39_report_1_class.html"
-  },
-  {
-    "date": "26/02/2021",
-    "observer": "Iddo_3270859",
     "title": "רקפת מצויה",
     "description": [
       ""
@@ -68773,28 +63517,6 @@
       "תל מראשה": {
         "latitude": 31.593061,
         "longitude": 34.89859799999999
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_39_report_1_class.html"
-  },
-  {
-    "date": "26/02/2021",
-    "observer": "Iddo_3270859",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "בית גוברין"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "בית גוברין": {
-        "latitude": 31.61288,
-        "longitude": 34.895568
       }
     },
     "coordinates": [],
@@ -69568,23 +64290,6 @@
     ],
     "flowers": [
       "לופית מצויה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_187_report_1_class.html"
-  },
-  {
-    "date": "24/02/2007",
-    "observer": "המטייל האנונימי",
-    "title": "אירוס הארגמן",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שמורת האירוסים הסמוכה למכון וינגייט"
-    ],
-    "flowers": [
-      "אירוס הארגמן"
     ],
     "geocoded_locations": {},
     "coordinates": [],
@@ -70407,23 +65112,6 @@
     "source_file": "tiuli_scraped_reports/page_182_report_1_class.html"
   },
   {
-    "date": "08/04/2007",
-    "observer": "המטייל האנונימי",
-    "title": "סחלבן החורש",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פרק הסלעים,הר סנה, תפן"
-    ],
-    "flowers": [
-      "סחלבן החורש"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_182_report_1_class.html"
-  },
-  {
     "date": "07/04/2007",
     "observer": "המטייל האנונימי",
     "title": "קוציץ סורי",
@@ -70520,23 +65208,6 @@
     ],
     "flowers": [
       "צהרון מצוי"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_182_report_1_class.html"
-  },
-  {
-    "date": "07/04/2007",
-    "observer": "המטייל האנונימי",
-    "title": "אדמונית החורש",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מסלול טיולים הר הלל"
-    ],
-    "flowers": [
-      "אדמונית החורש"
     ],
     "geocoded_locations": {},
     "coordinates": [],
@@ -71467,28 +66138,6 @@
     "source_file": "tiuli_scraped_reports/page_29_report_1_class.html"
   },
   {
-    "date": "02/03/2022",
-    "observer": "Iddo_3270859",
-    "title": "שקד מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מיני ישראל"
-    ],
-    "flowers": [
-      "שקד מצוי"
-    ],
-    "geocoded_locations": {
-      "מיני ישראל": {
-        "latitude": 31.8421649,
-        "longitude": 34.9690158
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_29_report_1_class.html"
-  },
-  {
     "date": "01/03/2022",
     "observer": "נירה_צ",
     "title": "כדן קטן-פרחים",
@@ -71821,28 +66470,6 @@
   {
     "date": "10/03/2017",
     "observer": "עידו מגן",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שמורת חרוצים"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "שמורת חרוצים": {
-        "latitude": 32.2243,
-        "longitude": 34.8579
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_64_report_1_class.html"
-  },
-  {
-    "date": "10/03/2017",
-    "observer": "עידו מגן",
     "title": "אירוס הארגמן",
     "description": [
       ""
@@ -71879,72 +66506,6 @@
       "שמורת חרוצים": {
         "latitude": 34.8579,
         "longitude": 32.2243
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_64_report_1_class.html"
-  },
-  {
-    "date": "10/03/2017",
-    "observer": "עידו מגן",
-    "title": "אירוס הארגמן",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער אילנות"
-    ],
-    "flowers": [
-      "אירוס הארגמן"
-    ],
-    "geocoded_locations": {
-      "יער אילנות": {
-        "latitude": 32.2922,
-        "longitude": 34.9011
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_64_report_1_class.html"
-  },
-  {
-    "date": "10/03/2017",
-    "observer": "עידו מגן",
-    "title": "שום הגלגל",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער אילנות"
-    ],
-    "flowers": [
-      "שום הגלגל"
-    ],
-    "geocoded_locations": {
-      "יער אילנות": {
-        "latitude": 32.2922,
-        "longitude": 34.9011
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_64_report_1_class.html"
-  },
-  {
-    "date": "09/03/2017",
-    "observer": "אלחי47",
-    "title": "דמומית ארץ-ישראלית",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הגליל התחתון עמקים-גבעת המורה"
-    ],
-    "flowers": [
-      "דמומית ארץ-ישראלית"
-    ],
-    "geocoded_locations": {
-      "הגליל התחתון עמקים-גבעת המורה": {
-        "latitude": 32.615,
-        "longitude": 35.457
       }
     },
     "coordinates": [],
@@ -72297,28 +66858,6 @@
       "בקעת הירדן-שמורת אום זוקא": {
         "latitude": 32.2775,
         "longitude": 35.5123
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_64_report_1_class.html"
-  },
-  {
-    "date": "05/03/2017",
-    "observer": "אלחי47",
-    "title": "צבעוני ההרים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "בקעת הירדן-שמורת אום זוקא"
-    ],
-    "flowers": [
-      "צבעוני ההרים"
-    ],
-    "geocoded_locations": {
-      "בקעת הירדן-שמורת אום זוקא": {
-        "latitude": 32.2766,
-        "longitude": 35.5122
       }
     },
     "coordinates": [],
@@ -75010,28 +69549,6 @@
     "source_file": "tiuli_scraped_reports/page_43_report_1_class.html"
   },
   {
-    "date": "18/12/2020",
-    "observer": "ybenshaya",
-    "title": "נרקיס מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל חצץ"
-    ],
-    "flowers": [
-      "נרקיס מצוי"
-    ],
-    "geocoded_locations": {
-      "נחל חצץ": {
-        "latitude": 30.89200899999999,
-        "longitude": 34.870378
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_43_report_1_class.html"
-  },
-  {
     "date": "16/12/2020",
     "observer": "אירית בן צבי",
     "title": "יפרוק המדבר",
@@ -75187,28 +69704,6 @@
   },
   {
     "date": "12/12/2020",
-    "observer": "atalonruthi",
-    "title": "כרכום חורפי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חורבת חנות"
-    ],
-    "flowers": [
-      "כרכום חורפי"
-    ],
-    "geocoded_locations": {
-      "חורבת חנות": {
-        "latitude": 31.71476500608875,
-        "longitude": 35.05929544707271
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_43_report_1_class.html"
-  },
-  {
-    "date": "12/12/2020",
     "observer": "NirK",
     "title": "כרכום חורפי",
     "description": [
@@ -75320,28 +69815,6 @@
   {
     "date": "11/12/2020",
     "observer": "Iddo_3270859",
-    "title": "כרכום חורפי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק בגין"
-    ],
-    "flowers": [
-      "כרכום חורפי"
-    ],
-    "geocoded_locations": {
-      "פארק בגין": {
-        "latitude": 31.7301575,
-        "longitude": 35.1131245
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_43_report_1_class.html"
-  },
-  {
-    "date": "11/12/2020",
-    "observer": "Iddo_3270859",
     "title": "נרקיס מצוי",
     "description": [
       ""
@@ -75356,50 +69829,6 @@
       "חניון הרב גרשון וחנה הדס": {
         "latitude": 31.7474723,
         "longitude": 35.03383
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_43_report_1_class.html"
-  },
-  {
-    "date": "11/12/2020",
-    "observer": "Iddo_3270859",
-    "title": "נרקיס מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער הקדושים"
-    ],
-    "flowers": [
-      "נרקיס מצוי"
-    ],
-    "geocoded_locations": {
-      "יער הקדושים": {
-        "latitude": 31.780806,
-        "longitude": 35.061326
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_43_report_1_class.html"
-  },
-  {
-    "date": "11/12/2020",
-    "observer": "Iddo_3270859",
-    "title": "נרקיס מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "עין קובי"
-    ],
-    "flowers": [
-      "נרקיס מצוי"
-    ],
-    "geocoded_locations": {
-      "עין קובי": {
-        "latitude": 31.7261111,
-        "longitude": 35.1155556
       }
     },
     "coordinates": [],
@@ -75540,28 +69969,6 @@
   {
     "date": "08/12/2020",
     "observer": "שיר בהר",
-    "title": "אירוס הסרגל",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער אלונה"
-    ],
-    "flowers": [
-      "אירוס הסרגל"
-    ],
-    "geocoded_locations": {
-      "יער אלונה": {
-        "latitude": 32.54915769999999,
-        "longitude": 35.018255
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_43_report_1_class.html"
-  },
-  {
-    "date": "08/12/2020",
-    "observer": "שיר בהר",
     "title": "רקפת מצויה",
     "description": [
       ""
@@ -75576,72 +69983,6 @@
       "מבוא חמה": {
         "latitude": 32.736701,
         "longitude": 35.655207
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_43_report_1_class.html"
-  },
-  {
-    "date": "08/12/2020",
-    "observer": "שיר בהר",
-    "title": "נרקיס מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שמורת טבע ביתן אהרון"
-    ],
-    "flowers": [
-      "נרקיס מצוי"
-    ],
-    "geocoded_locations": {
-      "שמורת טבע ביתן אהרון": {
-        "latitude": 32.36675,
-        "longitude": 34.8735589
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_43_report_1_class.html"
-  },
-  {
-    "date": "08/12/2020",
-    "observer": "שיר בהר",
-    "title": "נרקיס מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל רבה, ראש העין"
-    ],
-    "flowers": [
-      "נרקיס מצוי"
-    ],
-    "geocoded_locations": {
-      "נחל רבה, ראש העין": {
-        "latitude": 32.1004221,
-        "longitude": 34.9649045
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_43_report_1_class.html"
-  },
-  {
-    "date": "08/12/2020",
-    "observer": "שיר בהר",
-    "title": "רקפת מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הגן הבוטני בירושלים, הגן הבוטני, זלמן שניאור, ירושלים"
-    ],
-    "flowers": [
-      "רקפת מצויה"
-    ],
-    "geocoded_locations": {
-      "הגן הבוטני בירושלים, הגן הבוטני, זלמן שניאור, ירושלים": {
-        "latitude": 31.7662038,
-        "longitude": 35.2015665
       }
     },
     "coordinates": [],
@@ -77162,28 +71503,6 @@
   {
     "date": "06/03/2013",
     "observer": "גדי פולק",
-    "title": "פגוניה רכה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חולות כסוי"
-    ],
-    "flowers": [
-      "פגוניה רכה"
-    ],
-    "geocoded_locations": {
-      "חולות כסוי": {
-        "latitude": 29.9845,
-        "longitude": 34.9792
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_110_report_1_class.html"
-  },
-  {
-    "date": "06/03/2013",
-    "observer": "גדי פולק",
     "title": "פשתנית ססגונית",
     "description": [
       ""
@@ -77215,28 +71534,6 @@
     ],
     "flowers": [
       "שיכרון מדברי"
-    ],
-    "geocoded_locations": {
-      "חולות כסוי": {
-        "latitude": 29.9845,
-        "longitude": 34.9792
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_110_report_1_class.html"
-  },
-  {
-    "date": "06/03/2013",
-    "observer": "גדי פולק",
-    "title": "פגוניה ערבית",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חולות כסוי"
-    ],
-    "flowers": [
-      "פגוניה ערבית"
     ],
     "geocoded_locations": {
       "חולות כסוי": {
@@ -77732,50 +72029,6 @@
     "source_file": "tiuli_scraped_reports/page_60_report_1_class.html"
   },
   {
-    "date": "20/10/2017",
-    "observer": "עידו מגן",
-    "title": "חלמונית גדולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הר מירון, גליל עליון מזרחי"
-    ],
-    "flowers": [
-      "חלמונית גדולה"
-    ],
-    "geocoded_locations": {
-      "הר מירון, גליל עליון מזרחי": {
-        "latitude": 32.9975,
-        "longitude": 35.412222199999974
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_60_report_1_class.html"
-  },
-  {
-    "date": "20/10/2017",
-    "observer": "עידו מגן",
-    "title": "חלמונית גדולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הר מירון, גליל עליון מזרחי"
-    ],
-    "flowers": [
-      "חלמונית גדולה"
-    ],
-    "geocoded_locations": {
-      "הר מירון, גליל עליון מזרחי": {
-        "latitude": 32.994620524542455,
-        "longitude": 35.41715746458749
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_60_report_1_class.html"
-  },
-  {
     "date": "09/09/2017",
     "observer": "DanaT87",
     "title": "חצב מצוי",
@@ -77836,50 +72089,6 @@
       "חרמון": {
         "latitude": 33.3046,
         "longitude": 35.7877
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_60_report_1_class.html"
-  },
-  {
-    "date": "27/05/2017",
-    "observer": "אלחי47",
-    "title": "קדד אדום-פרחים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חרמון"
-    ],
-    "flowers": [
-      "קדד אדום-פרחים"
-    ],
-    "geocoded_locations": {
-      "חרמון": {
-        "latitude": 33.3046,
-        "longitude": 35.7877
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_60_report_1_class.html"
-  },
-  {
-    "date": "27/05/2017",
-    "observer": "אלחי47",
-    "title": "שום הלבנון",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חרמון"
-    ],
-    "flowers": [
-      "שום הלבנון"
-    ],
-    "geocoded_locations": {
-      "חרמון": {
-        "latitude": 33.3112,
-        "longitude": 35.7858
       }
     },
     "coordinates": [],
@@ -78240,28 +72449,6 @@
   {
     "date": "08/05/2017",
     "observer": "אלחי47",
-    "title": "מירונית סרגלית",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הגולן-יער אודם"
-    ],
-    "flowers": [
-      "מירונית סרגלית"
-    ],
-    "geocoded_locations": {
-      "הגולן-יער אודם": {
-        "latitude": 33.2165,
-        "longitude": 35.7587
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_60_report_1_class.html"
-  },
-  {
-    "date": "08/05/2017",
-    "observer": "אלחי47",
     "title": "בקיה דקת-עלים",
     "description": [
       ""
@@ -78276,72 +72463,6 @@
       "הגולן-יער אודם": {
         "latitude": 33.2166,
         "longitude": 35.7589
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_60_report_1_class.html"
-  },
-  {
-    "date": "08/05/2017",
-    "observer": "אלחי47",
-    "title": "בקיה דקת-עלים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הגולן-יער אודם"
-    ],
-    "flowers": [
-      "בקיה דקת-עלים"
-    ],
-    "geocoded_locations": {
-      "הגולן-יער אודם": {
-        "latitude": 33.2166,
-        "longitude": 35.7589
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_60_report_1_class.html"
-  },
-  {
-    "date": "08/05/2017",
-    "observer": "אלחי47",
-    "title": "שנק החורש",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הגולן יער אודם"
-    ],
-    "flowers": [
-      "שנק החורש"
-    ],
-    "geocoded_locations": {
-      "הגולן יער אודם": {
-        "latitude": 33.214,
-        "longitude": 35.7591
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_60_report_1_class.html"
-  },
-  {
-    "date": "08/05/2017",
-    "observer": "אלחי47",
-    "title": "שנק החורש",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הגולן יער אודם"
-    ],
-    "flowers": [
-      "שנק החורש"
-    ],
-    "geocoded_locations": {
-      "הגולן יער אודם": {
-        "latitude": 33.214,
-        "longitude": 35.7591
       }
     },
     "coordinates": [],
@@ -79058,46 +73179,12 @@
   {
     "date": "25/11/2012",
     "observer": "nilly6p1",
-    "title": "חלמונית גדולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער יתיר שביל החלמוניות"
-    ],
-    "flowers": [
-      "חלמונית גדולה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_119_report_1_class.html"
-  },
-  {
-    "date": "25/11/2012",
-    "observer": "nilly6p1",
     "title": "סתוונית היורה",
     "description": [
       ""
     ],
     "locations": [
       "דרך האבות בין אלון שבות לנווה דניאל"
-    ],
-    "flowers": [
-      "סתוונית היורה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_119_report_1_class.html"
-  },
-  {
-    "date": "25/11/2012",
-    "observer": "nilly6p1",
-    "title": "סתוונית היורה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "סוסיא"
     ],
     "flowers": [
       "סתוונית היורה"
@@ -80576,23 +74663,6 @@
     "source_file": "tiuli_scraped_reports/page_97_report_1_class.html"
   },
   {
-    "date": "01/02/2014",
-    "observer": "אלחי47",
-    "title": "מרסיה יפהפיה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שמורת אירוס הארגמן נתניה"
-    ],
-    "flowers": [
-      "מרסיה יפהפיה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_97_report_1_class.html"
-  },
-  {
     "date": "12/09/2021",
     "observer": "חנן - 4135815",
     "title": "חצב מצוי",
@@ -80653,28 +74723,6 @@
       "גבעת חומרה, פלמחים": {
         "latitude": 31.9322004,
         "longitude": 34.7082412
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_35_report_1_class.html"
-  },
-  {
-    "date": "10/09/2021",
-    "observer": "Iddo_3270859",
-    "title": "חצב מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הגן הלאומי גבעות הכורכר נס ציונה, דרך גבעות הכורכר, נס ציונה"
-    ],
-    "flowers": [
-      "חצב מצוי"
-    ],
-    "geocoded_locations": {
-      "הגן הלאומי גבעות הכורכר נס ציונה, דרך גבעות הכורכר, נס ציונה": {
-        "latitude": 31.9329054,
-        "longitude": 34.7862453
       }
     },
     "coordinates": [],
@@ -81291,28 +75339,6 @@
       "שביל המטוס סובב איתנים, איתנים": {
         "latitude": 31.778466,
         "longitude": 35.0950645
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_35_report_1_class.html"
-  },
-  {
-    "date": "24/04/2021",
-    "observer": "Iddo_3270859",
-    "title": "דבורנית גדולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חניון נחל קטלב"
-    ],
-    "flowers": [
-      "דבורנית גדולה"
-    ],
-    "geocoded_locations": {
-      "חניון נחל קטלב": {
-        "latitude": 31.7334785,
-        "longitude": 35.0747636
       }
     },
     "coordinates": [],
@@ -82068,50 +76094,6 @@
   },
   {
     "date": "03/02/2021",
-    "observer": "Iddo_3270859",
-    "title": "רקפת מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חורבת שוכה"
-    ],
-    "flowers": [
-      "רקפת מצויה"
-    ],
-    "geocoded_locations": {
-      "חורבת שוכה": {
-        "latitude": 31.6820222,
-        "longitude": 34.9741222
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_41_report_1_class.html"
-  },
-  {
-    "date": "03/02/2021",
-    "observer": "Iddo_3270859",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חורבת שוכה"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "חורבת שוכה": {
-        "latitude": 31.6820222,
-        "longitude": 34.9741222
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_41_report_1_class.html"
-  },
-  {
-    "date": "03/02/2021",
     "observer": "Itzik Yahini_4133518",
     "title": "נרקיס ניירי",
     "description": [
@@ -82289,28 +76271,6 @@
   {
     "date": "30/01/2021",
     "observer": "Iddo_3270859",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער בן שמן"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "יער בן שמן": {
-        "latitude": 31.9469992,
-        "longitude": 34.9507802
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_41_report_1_class.html"
-  },
-  {
-    "date": "30/01/2021",
-    "observer": "Iddo_3270859",
     "title": "עירית גדולה",
     "description": [
       ""
@@ -82342,50 +76302,6 @@
     ],
     "flowers": [
       "שקד מצוי"
-    ],
-    "geocoded_locations": {
-      "גבעת התיתורה, דרך יגאל אלון, מודיעין מכבים רעות": {
-        "latitude": 31.9027054,
-        "longitude": 35.0176871
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_41_report_1_class.html"
-  },
-  {
-    "date": "30/01/2021",
-    "observer": "Iddo_3270859",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "גבעת התיתורה, דרך יגאל אלון, מודיעין מכבים רעות"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "גבעת התיתורה, דרך יגאל אלון, מודיעין מכבים רעות": {
-        "latitude": 31.9027054,
-        "longitude": 35.0176871
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_41_report_1_class.html"
-  },
-  {
-    "date": "30/01/2021",
-    "observer": "Iddo_3270859",
-    "title": "רקפת מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "גבעת התיתורה, דרך יגאל אלון, מודיעין מכבים רעות"
-    ],
-    "flowers": [
-      "רקפת מצויה"
     ],
     "geocoded_locations": {
       "גבעת התיתורה, דרך יגאל אלון, מודיעין מכבים רעות": {
@@ -82597,28 +76513,6 @@
   {
     "date": "26/01/2021",
     "observer": "Iddo_3270859",
-    "title": "שקד מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "גן לאומי בית גוברין-מרשה"
-    ],
-    "flowers": [
-      "שקד מצוי"
-    ],
-    "geocoded_locations": {
-      "גן לאומי בית גוברין-מרשה": {
-        "latitude": 31.60163099999999,
-        "longitude": 34.895464
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_41_report_1_class.html"
-  },
-  {
-    "date": "26/01/2021",
-    "observer": "Iddo_3270859",
     "title": "כלנית מצויה",
     "description": [
       ""
@@ -82633,28 +76527,6 @@
       "תל בית שמש, בית שמש": {
         "latitude": 31.75030299999999,
         "longitude": 34.975495
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_41_report_1_class.html"
-  },
-  {
-    "date": "26/01/2021",
-    "observer": "Iddo_3270859",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "תל מראשה"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "תל מראשה": {
-        "latitude": 31.593061,
-        "longitude": 34.89859799999999
       }
     },
     "coordinates": [],
@@ -83619,23 +77491,6 @@
     ],
     "flowers": [
       "שושן צחור"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_121_report_1_class.html"
-  },
-  {
-    "date": "02/05/2012",
-    "observer": "אלחי47",
-    "title": "דבורנית גדולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "בשביל היורד מחורשת הארבעים לכביש עוספיה"
-    ],
-    "flowers": [
-      "דבורנית גדולה"
     ],
     "geocoded_locations": {},
     "coordinates": [],
@@ -84656,28 +78511,6 @@
   {
     "date": "06/12/2014",
     "observer": "גדי פולק",
-    "title": "כתמה עבת-שורשים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מצפור שי ע"
-    ],
-    "flowers": [
-      "כתמה עבת-שורשים"
-    ],
-    "geocoded_locations": {
-      "מצפור שי ע": {
-        "latitude": 32.5964,
-        "longitude": 35.0731
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_83_report_1_class.html"
-  },
-  {
-    "date": "06/12/2014",
-    "observer": "גדי פולק",
     "title": "זוטה לבנה",
     "description": [
       ""
@@ -84709,28 +78542,6 @@
     ],
     "flowers": [
       "שומר פשוט"
-    ],
-    "geocoded_locations": {
-      "מצפור שי ע": {
-        "latitude": 32.5964,
-        "longitude": 35.0731
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_83_report_1_class.html"
-  },
-  {
-    "date": "06/12/2014",
-    "observer": "גדי פולק",
-    "title": "נרקיס מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מצפור שי ע"
-    ],
-    "flowers": [
-      "נרקיס מצוי"
     ],
     "geocoded_locations": {
       "מצפור שי ע": {
@@ -84956,28 +78767,6 @@
       "יער הנשיא - צרעה, דרך הפסלים": {
         "latitude": 31.7904,
         "longitude": 34.9989
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_83_report_1_class.html"
-  },
-  {
-    "date": "29/11/2014",
-    "observer": "עידו מגן",
-    "title": "נרקיס מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער הקדושים"
-    ],
-    "flowers": [
-      "נרקיס מצוי"
-    ],
-    "geocoded_locations": {
-      "יער הקדושים": {
-        "latitude": 31.8116,
-        "longitude": 35.1223
       }
     },
     "coordinates": [],
@@ -85534,28 +79323,6 @@
     "source_file": "tiuli_scraped_reports/page_40_report_1_class.html"
   },
   {
-    "date": "22/02/2021",
-    "observer": "Dor_3497272",
-    "title": "רקפת מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער חורשים"
-    ],
-    "flowers": [
-      "רקפת מצויה"
-    ],
-    "geocoded_locations": {
-      "יער חורשים": {
-        "latitude": 32.14500799999999,
-        "longitude": 34.971757
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_40_report_1_class.html"
-  },
-  {
     "date": "21/02/2021",
     "observer": "David_3204148",
     "title": "טופח ריסני",
@@ -85996,28 +79763,6 @@
     "source_file": "tiuli_scraped_reports/page_40_report_1_class.html"
   },
   {
-    "date": "14/02/2021",
-    "observer": "EHB",
-    "title": "צהרון מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "גבעת התיתורה, דרך יגאל אלון, מודיעין מכבים רעות"
-    ],
-    "flowers": [
-      "צהרון מצוי"
-    ],
-    "geocoded_locations": {
-      "גבעת התיתורה, דרך יגאל אלון, מודיעין מכבים רעות": {
-        "latitude": 31.9027054,
-        "longitude": 35.0176871
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_40_report_1_class.html"
-  },
-  {
     "date": "13/02/2021",
     "observer": "Israel_3714533",
     "title": "שקד מצוי",
@@ -86122,50 +79867,6 @@
       "כביש 395/כביש 386, ירושלים": {
         "latitude": 31.772833,
         "longitude": 35.15361000000001
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_40_report_1_class.html"
-  },
-  {
-    "date": "13/02/2021",
-    "observer": "עידו מגן",
-    "title": "שקד מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "386, ירושלים"
-    ],
-    "flowers": [
-      "שקד מצוי"
-    ],
-    "geocoded_locations": {
-      "386, ירושלים": {
-        "latitude": 31.767656,
-        "longitude": 35.143513
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_40_report_1_class.html"
-  },
-  {
-    "date": "13/02/2021",
-    "observer": "עידו מגן",
-    "title": "כליל החורש",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חניון נחל קטלב"
-    ],
-    "flowers": [
-      "כליל החורש"
-    ],
-    "geocoded_locations": {
-      "חניון נחל קטלב": {
-        "latitude": 31.7334785,
-        "longitude": 35.0747636
       }
     },
     "coordinates": [],
@@ -86283,28 +79984,6 @@
   },
   {
     "date": "12/02/2021",
-    "observer": "Iddo_3270859",
-    "title": "שקד מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק ארזים, ירושלים"
-    ],
-    "flowers": [
-      "שקד מצוי"
-    ],
-    "geocoded_locations": {
-      "פארק ארזים, ירושלים": {
-        "latitude": 31.8011846,
-        "longitude": 35.1714792
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_40_report_1_class.html"
-  },
-  {
-    "date": "12/02/2021",
     "observer": "נירה_צ",
     "title": "עיריוני צהוב",
     "description": [
@@ -86337,28 +80016,6 @@
     ],
     "flowers": [
       "רקפת מצויה"
-    ],
-    "geocoded_locations": {
-      "נחל חלילים": {
-        "latitude": 31.80394,
-        "longitude": 35.164539
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_40_report_1_class.html"
-  },
-  {
-    "date": "12/02/2021",
-    "observer": "Iddo_3270859",
-    "title": "שקד מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל חלילים"
-    ],
-    "flowers": [
-      "שקד מצוי"
     ],
     "geocoded_locations": {
       "נחל חלילים": {
@@ -87910,28 +81567,6 @@
   {
     "date": "26/04/2019",
     "observer": "shargil.m",
-    "title": "שפתן מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חורשת הארבעים, נשר"
-    ],
-    "flowers": [
-      "שפתן מצוי"
-    ],
-    "geocoded_locations": {
-      "חורשת הארבעים, נשר": {
-        "latitude": 32.7545185,
-        "longitude": 35.02925959999993
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_53_report_1_class.html"
-  },
-  {
-    "date": "26/04/2019",
-    "observer": "shargil.m",
     "title": "רימונית הלוטם",
     "description": [
       ""
@@ -87968,28 +81603,6 @@
       "Unnamed Road, ישראל": {
         "latitude": 32.72608090353015,
         "longitude": 35.02177469541061
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_53_report_1_class.html"
-  },
-  {
-    "date": "23/04/2019",
-    "observer": "Meshy Ochana_4003283",
-    "title": "שנק החורש",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שדרות אבא חושי, נשר, ישראל"
-    ],
-    "flowers": [
-      "שנק החורש"
-    ],
-    "geocoded_locations": {
-      "שדרות אבא חושי, נשר, ישראל": {
-        "latitude": 32.7538262682549,
-        "longitude": 35.029272014020194
       }
     },
     "coordinates": [],
@@ -88144,50 +81757,6 @@
       "Unnamed Road, Nesher, ישראל": {
         "latitude": 32.7574919,
         "longitude": 35.02947560000007
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_53_report_1_class.html"
-  },
-  {
-    "date": "09/04/2019",
-    "observer": "יוחאי כורם",
-    "title": "עיריוני צהוב",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "Unnamed Road, Nesher, ישראל"
-    ],
-    "flowers": [
-      "עיריוני צהוב"
-    ],
-    "geocoded_locations": {
-      "Unnamed Road, Nesher, ישראל": {
-        "latitude": 32.7574919,
-        "longitude": 35.02947560000007
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_53_report_1_class.html"
-  },
-  {
-    "date": "09/04/2019",
-    "observer": "יוחאי כורם",
-    "title": "סיפן סגול",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "Unnamed Road, Nesher, ישראל"
-    ],
-    "flowers": [
-      "סיפן סגול"
-    ],
-    "geocoded_locations": {
-      "Unnamed Road, Nesher, ישראל": {
-        "latitude": 32.7561699,
-        "longitude": 35.03035139999997
       }
     },
     "coordinates": [],
@@ -88807,28 +82376,6 @@
   {
     "date": "11/03/2016",
     "observer": "עידו מגן",
-    "title": "סחלב פרפרני",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הר הטייסים"
-    ],
-    "flowers": [
-      "סחלב פרפרני"
-    ],
-    "geocoded_locations": {
-      "הר הטייסים": {
-        "latitude": 31.774,
-        "longitude": 35.0901
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_71_report_1_class.html"
-  },
-  {
-    "date": "11/03/2016",
-    "observer": "עידו מגן",
     "title": "כליל החורש",
     "description": [
       ""
@@ -88865,28 +82412,6 @@
       "תל שוכה עמק האלה": {
         "latitude": 31.682,
         "longitude": 34.9742
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_71_report_1_class.html"
-  },
-  {
-    "date": "11/03/2016",
-    "observer": "עידו מגן",
-    "title": "רקפת מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "תל שוכה עמק האלה"
-    ],
-    "flowers": [
-      "רקפת מצויה"
-    ],
-    "geocoded_locations": {
-      "תל שוכה עמק האלה": {
-        "latitude": 31.6819,
-        "longitude": 34.9741
       }
     },
     "coordinates": [],
@@ -88953,28 +82478,6 @@
       "אזור בית יערן עוספיה": {
         "latitude": 32.7393,
         "longitude": 35.0515
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_71_report_1_class.html"
-  },
-  {
-    "date": "10/03/2016",
-    "observer": "אלחי47",
-    "title": "סחלב שלוש השיניים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מחצבת חרייבה בכרמל"
-    ],
-    "flowers": [
-      "סחלב שלוש השיניים"
-    ],
-    "geocoded_locations": {
-      "מחצבת חרייבה בכרמל": {
-        "latitude": 32.7502,
-        "longitude": 35.0362
       }
     },
     "coordinates": [],
@@ -89377,50 +82880,6 @@
     "source_file": "tiuli_scraped_reports/page_71_report_1_class.html"
   },
   {
-    "date": "27/02/2016",
-    "observer": "איריס_בר",
-    "title": "יקינתון מזרחי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הר הילל"
-    ],
-    "flowers": [
-      "יקינתון מזרחי"
-    ],
-    "geocoded_locations": {
-      "הר הילל": {
-        "latitude": 32.9619,
-        "longitude": 35.4193
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_71_report_1_class.html"
-  },
-  {
-    "date": "27/02/2016",
-    "observer": "איריס_בר",
-    "title": "יקינתון מזרחי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הר הילל"
-    ],
-    "flowers": [
-      "יקינתון מזרחי"
-    ],
-    "geocoded_locations": {
-      "הר הילל": {
-        "latitude": 32.9619,
-        "longitude": 35.4193
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_71_report_1_class.html"
-  },
-  {
     "date": "26/02/2016",
     "observer": "עידו מגן",
     "title": "צהרון מצוי",
@@ -89767,23 +83226,6 @@
     "source_file": "tiuli_scraped_reports/page_164_report_1_class.html"
   },
   {
-    "date": "16/03/2009",
-    "observer": "המטייל האנונימי",
-    "title": "סחלב הגליל",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער החמישה, ליד אנדרטת הצבי"
-    ],
-    "flowers": [
-      "סחלב הגליל"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_164_report_1_class.html"
-  },
-  {
     "date": "15/03/2009",
     "observer": "המטייל האנונימי",
     "title": "סחלב הגליל",
@@ -90024,23 +83466,6 @@
   {
     "date": "13/03/2009",
     "observer": "המטייל האנונימי",
-    "title": "ציפורני-חתול מצויות",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "תל ערד"
-    ],
-    "flowers": [
-      "ציפורני-חתול מצויות"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_164_report_1_class.html"
-  },
-  {
-    "date": "13/03/2009",
-    "observer": "המטייל האנונימי",
     "title": "חרצית עטורה",
     "description": [
       ""
@@ -90177,23 +83602,6 @@
   {
     "date": "11/03/2009",
     "observer": "המטייל האנונימי",
-    "title": "אירוס הארגמן",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שמורת בני ציון"
-    ],
-    "flowers": [
-      "אירוס הארגמן"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_164_report_1_class.html"
-  },
-  {
-    "date": "11/03/2009",
-    "observer": "המטייל האנונימי",
     "title": "מקור-חסידה שעיר",
     "description": [
       ""
@@ -90237,23 +83645,6 @@
     ],
     "flowers": [
       "חומעה ורודה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_164_report_1_class.html"
-  },
-  {
-    "date": "11/03/2009",
-    "observer": "המטייל האנונימי",
-    "title": "צבעוני ההרים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שמורת הציבעונים עי מחצבת כפר גילעדי"
-    ],
-    "flowers": [
-      "צבעוני ההרים"
     ],
     "geocoded_locations": {},
     "coordinates": [],
@@ -90319,40 +83710,6 @@
     ],
     "locations": [
       "כביש גישה לעין חוד"
-    ],
-    "flowers": [
-      "צבעוני ההרים"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_164_report_1_class.html"
-  },
-  {
-    "date": "08/03/2009",
-    "observer": "צפורה",
-    "title": "צבעוני ההרים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל בוסתן"
-    ],
-    "flowers": [
-      "צבעוני ההרים"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_164_report_1_class.html"
-  },
-  {
-    "date": "08/03/2009",
-    "observer": "צפורה",
-    "title": "צבעוני ההרים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "בשביל המסומן הירוק לעין כפירה"
     ],
     "flowers": [
       "צבעוני ההרים"
@@ -91667,28 +85024,6 @@
     "source_file": "tiuli_scraped_reports/page_34_report_1_class.html"
   },
   {
-    "date": "11/12/2021",
-    "observer": "Iddo_3270859",
-    "title": "נרקיס מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "אנדרטת אגרוף ורומח"
-    ],
-    "flowers": [
-      "נרקיס מצוי"
-    ],
-    "geocoded_locations": {
-      "אנדרטת אגרוף ורומח": {
-        "latitude": 32.03368974343822,
-        "longitude": 34.95805151776949
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_34_report_1_class.html"
-  },
-  {
     "date": "08/12/2021",
     "observer": "אלחי47",
     "title": "כרכום גיירדו",
@@ -91793,28 +85128,6 @@
       "פארק בגין": {
         "latitude": 31.7301575,
         "longitude": 35.1131245
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_34_report_1_class.html"
-  },
-  {
-    "date": "04/12/2021",
-    "observer": "Iddo_3270859",
-    "title": "כרכום חורפי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חורבת חנות"
-    ],
-    "flowers": [
-      "כרכום חורפי"
-    ],
-    "geocoded_locations": {
-      "חורבת חנות": {
-        "latitude": 31.7116546,
-        "longitude": 35.04688640000001
       }
     },
     "coordinates": [],
@@ -92218,28 +85531,6 @@
   },
   {
     "date": "02/10/2021",
-    "observer": "מ.פ 1967",
-    "title": "חצב מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שמורת גברעם"
-    ],
-    "flowers": [
-      "חצב מצוי"
-    ],
-    "geocoded_locations": {
-      "שמורת גברעם": {
-        "latitude": 31.576342252388066,
-        "longitude": 34.61951187663913
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_34_report_1_class.html"
-  },
-  {
-    "date": "02/10/2021",
     "observer": "עידו מגן",
     "title": "חצב מצוי",
     "description": [
@@ -92497,28 +85788,6 @@
       "שביל המטוס סובב איתנים, איתנים": {
         "latitude": 31.779213145727724,
         "longitude": 35.09577145377872
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_12_report_1_class.html"
-  },
-  {
-    "date": "29/04/2023",
-    "observer": "Iddo_3270859",
-    "title": "בן-סחלב צריפי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "גבעת יערים"
-    ],
-    "flowers": [
-      "בן-סחלב צריפי"
-    ],
-    "geocoded_locations": {
-      "גבעת יערים": {
-        "latitude": 31.78198502517902,
-        "longitude": 35.10539170946575
       }
     },
     "coordinates": [],
@@ -94022,28 +87291,6 @@
   },
   {
     "date": "30/03/2022",
-    "observer": "Iddo_3270859",
-    "title": "כליל החורש",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "משמר איילון"
-    ],
-    "flowers": [
-      "כליל החורש"
-    ],
-    "geocoded_locations": {
-      "משמר איילון": {
-        "latitude": 31.872478,
-        "longitude": 34.943253
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_27_report_1_class.html"
-  },
-  {
-    "date": "30/03/2022",
     "observer": "אלחי47",
     "title": "סגולית מחומשת",
     "description": [
@@ -95478,23 +88725,6 @@
   {
     "date": "06/01/2007",
     "observer": "המטייל האנונימי",
-    "title": "יקינתון מזרחי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מצפון מזרח לבית הכנסת העתיק בחרבת עמודים"
-    ],
-    "flowers": [
-      "יקינתון מזרחי"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_190_report_1_class.html"
-  },
-  {
-    "date": "06/01/2007",
-    "observer": "המטייל האנונימי",
     "title": "כלנית מצויה",
     "description": [
       ""
@@ -96532,40 +89762,6 @@
   {
     "date": "23/01/2010",
     "observer": "המטייל האנונימי",
-    "title": "רקפת יוונית",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הר מירון -"
-    ],
-    "flowers": [
-      "רקפת יוונית"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_153_report_1_class.html"
-  },
-  {
-    "date": "23/01/2010",
-    "observer": "המטייל האנונימי",
-    "title": "אירוס הלבנון",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מירון - שביל הפסגה"
-    ],
-    "flowers": [
-      "אירוס הלבנון"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_153_report_1_class.html"
-  },
-  {
-    "date": "23/01/2010",
-    "observer": "המטייל האנונימי",
     "title": "רומולאה סגלולית",
     "description": [
       ""
@@ -96725,23 +89921,6 @@
     ],
     "locations": [
       "שמורת  הטבע  רמת  הנדיב  ע''י  זכרון  יעקב"
-    ],
-    "flowers": [
-      "עירית גדולה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_153_report_1_class.html"
-  },
-  {
-    "date": "23/01/2010",
-    "observer": "המטייל האנונימי",
-    "title": "עירית גדולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "   שמורת  הטבע   רמת  הנדיב  ע''י  זכרון  יעקב"
     ],
     "flowers": [
       "עירית גדולה"
@@ -96932,23 +90111,6 @@
     ],
     "flowers": [
       "נרקיס מצוי"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_153_report_1_class.html"
-  },
-  {
-    "date": "16/01/2010",
-    "observer": "המטייל האנונימי",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שביל שחור מפסגת הר מירון לביהס שדה מירון"
-    ],
-    "flowers": [
-      "כלנית מצויה"
     ],
     "geocoded_locations": {},
     "coordinates": [],
@@ -97260,28 +90422,6 @@
     "source_file": "tiuli_scraped_reports/page_22_report_1_class.html"
   },
   {
-    "date": "11/12/2022",
-    "observer": "אלחי47",
-    "title": "אירוס הסרגל",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער קרן כרמל"
-    ],
-    "flowers": [
-      "אירוס הסרגל"
-    ],
-    "geocoded_locations": {
-      "יער קרן כרמל": {
-        "latitude": 32.648,
-        "longitude": 35.075
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_22_report_1_class.html"
-  },
-  {
     "date": "09/12/2022",
     "observer": "Iddo_3270859",
     "title": "רקפת מצויה",
@@ -97371,28 +90511,6 @@
   },
   {
     "date": "03/12/2022",
-    "observer": "Iddo_3270859",
-    "title": "כרכום חורפי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חורבת חנות"
-    ],
-    "flowers": [
-      "כרכום חורפי"
-    ],
-    "geocoded_locations": {
-      "חורבת חנות": {
-        "latitude": 31.7116546,
-        "longitude": 35.04688640000001
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_22_report_1_class.html"
-  },
-  {
-    "date": "03/12/2022",
     "observer": "tabak1",
     "title": "סתוונית היורה",
     "description": [
@@ -97452,50 +90570,6 @@
       "יער ראש העין, ראש העין": {
         "latitude": 32.0988349,
         "longitude": 34.9822174
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_22_report_1_class.html"
-  },
-  {
-    "date": "02/12/2022",
-    "observer": "Iddo_3270859",
-    "title": "נרקיס מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק יער שהם, שוהם"
-    ],
-    "flowers": [
-      "נרקיס מצוי"
-    ],
-    "geocoded_locations": {
-      "פארק יער שהם, שוהם": {
-        "latitude": 31.9974478,
-        "longitude": 34.955336
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_22_report_1_class.html"
-  },
-  {
-    "date": "02/12/2022",
-    "observer": "Iddo_3270859",
-    "title": "נרקיס מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "אנדרטת אגרוף ורומח"
-    ],
-    "flowers": [
-      "נרקיס מצוי"
-    ],
-    "geocoded_locations": {
-      "אנדרטת אגרוף ורומח": {
-        "latitude": 32.03367980000001,
-        "longitude": 34.9576753
       }
     },
     "coordinates": [],
@@ -97900,28 +90974,6 @@
   {
     "date": "11/11/2022",
     "observer": "Iddo_3270859",
-    "title": "נרקיס מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער הקדושים"
-    ],
-    "flowers": [
-      "נרקיס מצוי"
-    ],
-    "geocoded_locations": {
-      "יער הקדושים": {
-        "latitude": 31.780089407203466,
-        "longitude": 35.05506687339673
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_22_report_1_class.html"
-  },
-  {
-    "date": "11/11/2022",
-    "observer": "Iddo_3270859",
     "title": "סתוונית היורה",
     "description": [
       ""
@@ -97936,50 +90988,6 @@
       "יער הקדושים": {
         "latitude": 31.780028333747556,
         "longitude": 35.055017300333
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_22_report_1_class.html"
-  },
-  {
-    "date": "11/11/2022",
-    "observer": "Iddo_3270859",
-    "title": "סתוונית היורה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חורבת חנות"
-    ],
-    "flowers": [
-      "סתוונית היורה"
-    ],
-    "geocoded_locations": {
-      "חורבת חנות": {
-        "latitude": 31.7116546,
-        "longitude": 35.04688640000001
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_22_report_1_class.html"
-  },
-  {
-    "date": "11/11/2022",
-    "observer": "Iddo_3270859",
-    "title": "סתוונית היורה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חניון לילה בר גיורא, בר גיורא"
-    ],
-    "flowers": [
-      "סתוונית היורה"
-    ],
-    "geocoded_locations": {
-      "חניון לילה בר גיורא, בר גיורא": {
-        "latitude": 31.735901271434248,
-        "longitude": 35.07408790966694
       }
     },
     "coordinates": [],
@@ -98002,28 +91010,6 @@
       "הר סנסן": {
         "latitude": 31.6997222,
         "longitude": 35.0805556
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_22_report_1_class.html"
-  },
-  {
-    "date": "09/11/2022",
-    "observer": "מ.פ 1967",
-    "title": "חלמונית גדולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חניון להבים חלמוניות, להבים"
-    ],
-    "flowers": [
-      "חלמונית גדולה"
-    ],
-    "geocoded_locations": {
-      "חניון להבים חלמוניות, להבים": {
-        "latitude": 31.3709323,
-        "longitude": 34.82608279999999
       }
     },
     "coordinates": [],
@@ -98178,28 +91164,6 @@
       "יער הקדושים": {
         "latitude": 31.780806,
         "longitude": 35.061326
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_14_report_1_class.html"
-  },
-  {
-    "date": "01/04/2023",
-    "observer": "Iddo_3270859",
-    "title": "נורית אסיה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "גבעת יערים"
-    ],
-    "flowers": [
-      "נורית אסיה"
-    ],
-    "geocoded_locations": {
-      "גבעת יערים": {
-        "latitude": 31.786089,
-        "longitude": 35.09277
       }
     },
     "coordinates": [],
@@ -98846,28 +91810,6 @@
   {
     "date": "22/03/2023",
     "observer": "אלחי47",
-    "title": "ניאוטינאה תמימה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "רוגום גנים, קרית יובל"
-    ],
-    "flowers": [
-      "ניאוטינאה תמימה"
-    ],
-    "geocoded_locations": {
-      "רוגום גנים, קרית יובל": {
-        "latitude": 31.782,
-        "longitude": 35.101
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_14_report_1_class.html"
-  },
-  {
-    "date": "22/03/2023",
-    "observer": "אלחי47",
     "title": "לשון-פר איטלקית",
     "description": [
       ""
@@ -99031,28 +91973,6 @@
       "חניון הרב גרשון וחנה הדס": {
         "latitude": 31.7474723,
         "longitude": 35.03383
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_14_report_1_class.html"
-  },
-  {
-    "date": "17/03/2023",
-    "observer": "Iddo_3270859",
-    "title": "סחלב אנטולי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק עצמאות ארצות הברית, מטע"
-    ],
-    "flowers": [
-      "סחלב אנטולי"
-    ],
-    "geocoded_locations": {
-      "פארק עצמאות ארצות הברית, מטע": {
-        "latitude": 31.748216185937242,
-        "longitude": 35.045861219253
       }
     },
     "coordinates": [],
@@ -99675,28 +92595,6 @@
     "source_file": "tiuli_scraped_reports/page_8_report_1_class.html"
   },
   {
-    "date": "03/01/2024",
-    "observer": "אלחי47",
-    "title": "זוטה לבנה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חורשת הארבעים, חורשת ה40, נשר"
-    ],
-    "flowers": [
-      "זוטה לבנה"
-    ],
-    "geocoded_locations": {
-      "חורשת הארבעים, חורשת ה40, נשר": {
-        "latitude": 32.758,
-        "longitude": 35.029
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_8_report_1_class.html"
-  },
-  {
     "date": "31/12/2023",
     "observer": "tali1874",
     "title": "אירוס ארץ-ישראלי",
@@ -99757,28 +92655,6 @@
       "הגן הלאומי גבעות הכורכר נס ציונה, דרך גבעות הכורכר, נס ציונה": {
         "latitude": 31.9329054,
         "longitude": 34.7862453
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_8_report_1_class.html"
-  },
-  {
-    "date": "30/12/2023",
-    "observer": "Iddo_3270859",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מערות אפקה, תל אביב-יפו"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "מערות אפקה, תל אביב-יפו": {
-        "latitude": 32.1295327,
-        "longitude": 34.8094149
       }
     },
     "coordinates": [],
@@ -100596,23 +93472,6 @@
   {
     "date": "14/02/2010",
     "observer": "המטייל האנונימי",
-    "title": "צבעוני ההרים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל ספונים"
-    ],
-    "flowers": [
-      "צבעוני ההרים"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_151_report_1_class.html"
-  },
-  {
-    "date": "14/02/2010",
-    "observer": "המטייל האנונימי",
     "title": "עירית גדולה",
     "description": [
       ""
@@ -100707,23 +93566,6 @@
     ],
     "flowers": [
       "פשתה שעירה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_151_report_1_class.html"
-  },
-  {
-    "date": "13/02/2010",
-    "observer": "המטייל האנונימי",
-    "title": "תורמוס ההרים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל תבור, מרבדים נפלאים"
-    ],
-    "flowers": [
-      "תורמוס ההרים"
     ],
     "geocoded_locations": {},
     "coordinates": [],
@@ -101153,28 +93995,6 @@
   {
     "date": "09/03/2019",
     "observer": "עידו מגן",
-    "title": "רקפת מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק עצמאות ארה\"ב"
-    ],
-    "flowers": [
-      "רקפת מצויה"
-    ],
-    "geocoded_locations": {
-      "פארק עצמאות ארה\"ב": {
-        "latitude": 31.74554,
-        "longitude": 35.03829799999994
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_54_report_1_class.html"
-  },
-  {
-    "date": "09/03/2019",
-    "observer": "עידו מגן",
     "title": "צבעוני ההרים",
     "description": [
       ""
@@ -101437,50 +94257,6 @@
     "source_file": "tiuli_scraped_reports/page_54_report_1_class.html"
   },
   {
-    "date": "24/02/2019",
-    "observer": "יואל נקש",
-    "title": "סחלב נקוד",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הרי בינימין"
-    ],
-    "flowers": [
-      "סחלב נקוד"
-    ],
-    "geocoded_locations": {
-      "הרי בינימין": {
-        "latitude": 31.96245298581015,
-        "longitude": 35.112932880086646
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_54_report_1_class.html"
-  },
-  {
-    "date": "24/02/2019",
-    "observer": "יואל נקש",
-    "title": "סחלב נקוד",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הרי בינימין"
-    ],
-    "flowers": [
-      "סחלב נקוד"
-    ],
-    "geocoded_locations": {
-      "הרי בינימין": {
-        "latitude": 31.96245298581015,
-        "longitude": 35.112932880086646
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_54_report_1_class.html"
-  },
-  {
     "date": "23/02/2019",
     "observer": "אבי_3375851",
     "title": "אירוס נצרתי",
@@ -101526,28 +94302,6 @@
   },
   {
     "date": "23/02/2019",
-    "observer": "tabak1",
-    "title": "רקפת מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "גבעת הרקפות"
-    ],
-    "flowers": [
-      "רקפת מצויה"
-    ],
-    "geocoded_locations": {
-      "גבעת הרקפות": {
-        "latitude": 32.560528,
-        "longitude": 35.08457899999996
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_54_report_1_class.html"
-  },
-  {
-    "date": "23/02/2019",
     "observer": "עידו מגן",
     "title": "תורמוס ארץ-ישראלי",
     "description": [
@@ -101563,28 +94317,6 @@
       "שדרת תש\"ח, ראשון לציון": {
         "latitude": 31.9551702,
         "longitude": 34.79432489999999
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_54_report_1_class.html"
-  },
-  {
-    "date": "23/02/2019",
-    "observer": "tabak1",
-    "title": "רקפת מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "אלפי מנשה"
-    ],
-    "flowers": [
-      "רקפת מצויה"
-    ],
-    "geocoded_locations": {
-      "אלפי מנשה": {
-        "latitude": 32.170631,
-        "longitude": 35.014858000000004
       }
     },
     "coordinates": [],
@@ -101747,28 +94479,6 @@
   {
     "date": "15/02/2019",
     "observer": "עידו מגן",
-    "title": "רקפת מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק עצמאות ארה\"ב"
-    ],
-    "flowers": [
-      "רקפת מצויה"
-    ],
-    "geocoded_locations": {
-      "פארק עצמאות ארה\"ב": {
-        "latitude": 31.74554,
-        "longitude": 35.03829799999994
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_54_report_1_class.html"
-  },
-  {
-    "date": "15/02/2019",
-    "observer": "עידו מגן",
     "title": "צבעוני ההרים",
     "description": [
       ""
@@ -101783,72 +94493,6 @@
       "פארק עצמאות ארה\"ב": {
         "latitude": 31.74554,
         "longitude": 35.03829799999994
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_54_report_1_class.html"
-  },
-  {
-    "date": "15/02/2019",
-    "observer": "עידו מגן",
-    "title": "עירית גדולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק עצמאות ארה\"ב"
-    ],
-    "flowers": [
-      "עירית גדולה"
-    ],
-    "geocoded_locations": {
-      "פארק עצמאות ארה\"ב": {
-        "latitude": 31.746865282327335,
-        "longitude": 35.03628284543129
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_54_report_1_class.html"
-  },
-  {
-    "date": "15/02/2019",
-    "observer": "עידו מגן",
-    "title": "שקד מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מיני ישראל"
-    ],
-    "flowers": [
-      "שקד מצוי"
-    ],
-    "geocoded_locations": {
-      "מיני ישראל": {
-        "latitude": 31.84831053848596,
-        "longitude": 34.96742940106071
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_54_report_1_class.html"
-  },
-  {
-    "date": "15/02/2019",
-    "observer": "עידו מגן",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מכון טיהור שפכים, ירושלים"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "מכון טיהור שפכים, ירושלים": {
-        "latitude": 31.757305,
-        "longitude": 35.10463200000004
       }
     },
     "coordinates": [],
@@ -101871,28 +94515,6 @@
       "פארק יקום, יקום": {
         "latitude": 32.25573799999999,
         "longitude": 34.83771100000001
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_54_report_1_class.html"
-  },
-  {
-    "date": "14/02/2019",
-    "observer": "gadi57",
-    "title": "אירוס שחום",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק יקום"
-    ],
-    "flowers": [
-      "אירוס שחום"
-    ],
-    "geocoded_locations": {
-      "פארק יקום": {
-        "latitude": 32.256324019722136,
-        "longitude": 34.84016092422098
       }
     },
     "coordinates": [],
@@ -102047,28 +94669,6 @@
       "חורבת שרישה": {
         "latitude": 31.821855,
         "longitude": 34.93947300000002
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_54_report_1_class.html"
-  },
-  {
-    "date": "08/02/2019",
-    "observer": "עידו מגן",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל ענבה, מודיעין מכבים רעות"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "נחל ענבה, מודיעין מכבים רעות": {
-        "latitude": 31.8988569,
-        "longitude": 34.979248600000005
       }
     },
     "coordinates": [],
@@ -103727,28 +96327,6 @@
   {
     "date": "14/06/2011",
     "observer": "גדי פולק",
-    "title": "נופר צהוב",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "ברכת הנופרים ירקון"
-    ],
-    "flowers": [
-      "נופר צהוב"
-    ],
-    "geocoded_locations": {
-      "ברכת הנופרים ירקון": {
-        "latitude": 32.1095,
-        "longitude": 34.9222
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_131_report_1_class.html"
-  },
-  {
-    "date": "14/06/2011",
-    "observer": "גדי פולק",
     "title": "נענה משובלת",
     "description": [
       ""
@@ -103758,72 +96336,6 @@
     ],
     "flowers": [
       "נענה משובלת"
-    ],
-    "geocoded_locations": {
-      "ברכת הנופרים ירקון": {
-        "latitude": 32.1095,
-        "longitude": 34.9222
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_131_report_1_class.html"
-  },
-  {
-    "date": "14/06/2011",
-    "observer": "גדי פולק",
-    "title": "סוף מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "ברכת הנופרים ירקון"
-    ],
-    "flowers": [
-      "סוף מצוי"
-    ],
-    "geocoded_locations": {
-      "ברכת הנופרים ירקון": {
-        "latitude": 32.1095,
-        "longitude": 34.9222
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_131_report_1_class.html"
-  },
-  {
-    "date": "14/06/2011",
-    "observer": "גדי פולק",
-    "title": "ערבה מחודדת",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "ברכת הנופרים ירקון"
-    ],
-    "flowers": [
-      "ערבה מחודדת"
-    ],
-    "geocoded_locations": {
-      "ברכת הנופרים ירקון": {
-        "latitude": 32.1095,
-        "longitude": 34.9222
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_131_report_1_class.html"
-  },
-  {
-    "date": "14/06/2011",
-    "observer": "גדי פולק",
-    "title": "פטל קדוש",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "ברכת הנופרים ירקון"
-    ],
-    "flowers": [
-      "פטל קדוש"
     ],
     "geocoded_locations": {
       "ברכת הנופרים ירקון": {
@@ -103859,28 +96371,6 @@
   {
     "date": "14/06/2011",
     "observer": "גדי פולק",
-    "title": "קנה מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "ברכת הנופרים ירקון"
-    ],
-    "flowers": [
-      "קנה מצוי"
-    ],
-    "geocoded_locations": {
-      "ברכת הנופרים ירקון": {
-        "latitude": 32.1095,
-        "longitude": 34.9222
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_131_report_1_class.html"
-  },
-  {
-    "date": "14/06/2011",
-    "observer": "גדי פולק",
     "title": "שומר פשוט",
     "description": [
       ""
@@ -103890,50 +96380,6 @@
     ],
     "flowers": [
       "שומר פשוט"
-    ],
-    "geocoded_locations": {
-      "ברכת הנופרים ירקון": {
-        "latitude": 32.1095,
-        "longitude": 34.9222
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_131_report_1_class.html"
-  },
-  {
-    "date": "14/06/2011",
-    "observer": "גדי פולק",
-    "title": "שנית גדולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "ברכת הנופרים ירקון"
-    ],
-    "flowers": [
-      "שנית גדולה"
-    ],
-    "geocoded_locations": {
-      "ברכת הנופרים ירקון": {
-        "latitude": 32.1095,
-        "longitude": 34.9222
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_131_report_1_class.html"
-  },
-  {
-    "date": "14/06/2011",
-    "observer": "גדי פולק",
-    "title": "תולענית דוקרנית",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "ברכת הנופרים ירקון"
-    ],
-    "flowers": [
-      "תולענית דוקרנית"
     ],
     "geocoded_locations": {
       "ברכת הנופרים ירקון": {
@@ -105072,23 +97518,6 @@
     "source_file": "tiuli_scraped_reports/page_132_report_1_class.html"
   },
   {
-    "date": "09/05/2011",
-    "observer": "אלחי47",
-    "title": "צורית ספרדית",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל כזיבבשביל השחור היורד מהילה לקרן ברתות"
-    ],
-    "flowers": [
-      "צורית ספרדית"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_132_report_1_class.html"
-  },
-  {
     "date": "07/05/2011",
     "observer": "אלחי47",
     "title": "דורבנית התבור",
@@ -105740,28 +98169,6 @@
   },
   {
     "date": "28/02/2015",
-    "observer": "עידו מגן",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק רמות מנשה ליד קיבוץ הזורע"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "פארק רמות מנשה ליד קיבוץ הזורע": {
-        "latitude": 32.5873,
-        "longitude": 35.1446
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_79_report_1_class.html"
-  },
-  {
-    "date": "28/02/2015",
     "observer": "flowerlover",
     "title": "עכנאי זיפני",
     "description": [
@@ -106019,28 +98426,6 @@
       "חוף הבונים": {
         "latitude": 32.6338,
         "longitude": 34.9219
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_79_report_1_class.html"
-  },
-  {
-    "date": "27/02/2015",
-    "observer": "איריס_בר",
-    "title": "שפתן מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חוף הבונים"
-    ],
-    "flowers": [
-      "שפתן מצוי"
-    ],
-    "geocoded_locations": {
-      "חוף הבונים": {
-        "latitude": 32.6363,
-        "longitude": 34.9238
       }
     },
     "coordinates": [],
@@ -106599,28 +98984,6 @@
   {
     "date": "17/07/2023",
     "observer": "אלחי47",
-    "title": "קערורית נאדית",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "אתר החרמון"
-    ],
-    "flowers": [
-      "קערורית נאדית"
-    ],
-    "geocoded_locations": {
-      "אתר החרמון": {
-        "latitude": 33.306,
-        "longitude": 35.784
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_10_report_1_class.html"
-  },
-  {
-    "date": "17/07/2023",
-    "observer": "אלחי47",
     "title": "געדה מזרחית",
     "description": [
       ""
@@ -106811,28 +99174,6 @@
       "יקינטון המים": {
         "latitude": 32.24488480000001,
         "longitude": 34.8751454
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_10_report_1_class.html"
-  },
-  {
-    "date": "21/06/2023",
-    "observer": "נק999",
-    "title": "איכהורניה עבת-רגל",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "בריכת יקינטון, כביש 2, נתניה"
-    ],
-    "flowers": [
-      "איכהורניה עבת-רגל"
-    ],
-    "geocoded_locations": {
-      "בריכת יקינטון, כביש 2, נתניה": {
-        "latitude": 32.3312597,
-        "longitude": 34.8736421
       }
     },
     "coordinates": [],
@@ -107303,50 +99644,6 @@
   {
     "date": "06/11/2016",
     "observer": "אלחי47",
-    "title": "חלמונית גדולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הר מירון הגליל העליון"
-    ],
-    "flowers": [
-      "חלמונית גדולה"
-    ],
-    "geocoded_locations": {
-      "הר מירון הגליל העליון": {
-        "latitude": 32.9951,
-        "longitude": 35.4169
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_68_report_1_class.html"
-  },
-  {
-    "date": "06/11/2016",
-    "observer": "אלחי47",
-    "title": "כרכום נאה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הר מירון הגליל העליון"
-    ],
-    "flowers": [
-      "כרכום נאה"
-    ],
-    "geocoded_locations": {
-      "הר מירון הגליל העליון": {
-        "latitude": 32.9943,
-        "longitude": 35.4155
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_68_report_1_class.html"
-  },
-  {
-    "date": "06/11/2016",
-    "observer": "אלחי47",
     "title": "כרכום נאה",
     "description": [
       ""
@@ -107383,28 +99680,6 @@
       "שמורת מערת פער גליל עליון": {
         "latitude": 33.0314,
         "longitude": 35.3859
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_68_report_1_class.html"
-  },
-  {
-    "date": "06/11/2016",
-    "observer": "אלחי47",
-    "title": "כרכום צהבהב",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שמורת מערת פער-גליל עליון"
-    ],
-    "flowers": [
-      "כרכום צהבהב"
-    ],
-    "geocoded_locations": {
-      "שמורת מערת פער-גליל עליון": {
-        "latitude": 33.0315,
-        "longitude": 35.386
       }
     },
     "coordinates": [],
@@ -107625,28 +99900,6 @@
       "הר שיפון רמת הגולן": {
         "latitude": 33.069,
         "longitude": 35.7723
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_68_report_1_class.html"
-  },
-  {
-    "date": "29/10/2016",
-    "observer": "אלחי47",
-    "title": "סתוונית התשבץ",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הר יוסיפון רמת הגולן"
-    ],
-    "flowers": [
-      "סתוונית התשבץ"
-    ],
-    "geocoded_locations": {
-      "הר יוסיפון רמת הגולן": {
-        "latitude": 33.056,
-        "longitude": 35.7857
       }
     },
     "coordinates": [],
@@ -108181,28 +100434,6 @@
     "source_file": "tiuli_scraped_reports/page_68_report_1_class.html"
   },
   {
-    "date": "31/07/2016",
-    "observer": "אלחי47",
-    "title": "הרנוג השיטים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "ליד מאגר רשפים עמק המעינות"
-    ],
-    "flowers": [
-      "הרנוג השיטים"
-    ],
-    "geocoded_locations": {
-      "ליד מאגר רשפים עמק המעינות": {
-        "latitude": 32.4603,
-        "longitude": 35.4608
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_68_report_1_class.html"
-  },
-  {
     "date": "19/07/2016",
     "observer": "אלחי47",
     "title": "אבובית החרטומים",
@@ -108333,23 +100564,6 @@
     ],
     "locations": [
       "צומת המפלים"
-    ],
-    "flowers": [
-      "אירוס החרמון"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_173_report_1_class.html"
-  },
-  {
-    "date": "20/03/2008",
-    "observer": "המטייל האנונימי",
-    "title": "אירוס החרמון",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מפל עיט"
     ],
     "flowers": [
       "אירוס החרמון"
@@ -108520,23 +100734,6 @@
     ],
     "locations": [
       "יער דודאים"
-    ],
-    "flowers": [
-      "אירוס שחום"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_173_report_1_class.html"
-  },
-  {
-    "date": "15/03/2008",
-    "observer": "המטייל האנונימי",
-    "title": "אירוס שחום",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "צמת גורל"
     ],
     "flowers": [
       "אירוס שחום"
@@ -108778,23 +100975,6 @@
     ],
     "flowers": [
       "צהרון מצוי"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_173_report_1_class.html"
-  },
-  {
-    "date": "14/03/2008",
-    "observer": "המטייל האנונימי",
-    "title": "צבעוני ההרים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער ראש העין בתחילת שביל הפריחה"
-    ],
-    "flowers": [
-      "צבעוני ההרים"
     ],
     "geocoded_locations": {},
     "coordinates": [],
@@ -109058,23 +101238,6 @@
   {
     "date": "08/03/2008",
     "observer": "המטייל האנונימי",
-    "title": "תורמוס ההרים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "גבעת הג'מוסים-מול גבעת המורה ליד בלפוריה"
-    ],
-    "flowers": [
-      "תורמוס ההרים"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_173_report_1_class.html"
-  },
-  {
-    "date": "08/03/2008",
-    "observer": "המטייל האנונימי",
     "title": "סחלב הגליל",
     "description": [
       ""
@@ -109084,23 +101247,6 @@
     ],
     "flowers": [
       "סחלב הגליל"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_173_report_1_class.html"
-  },
-  {
-    "date": "08/03/2008",
-    "observer": "המטייל האנונימי",
-    "title": "סחלב פרפרני",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "אנדרטת האש"
-    ],
-    "flowers": [
-      "סחלב פרפרני"
     ],
     "geocoded_locations": {},
     "coordinates": [],
@@ -109544,28 +101690,6 @@
   {
     "date": "05/04/2015",
     "observer": "shargil.m",
-    "title": "תלתן הארגמן",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק בריטניה"
-    ],
-    "flowers": [
-      "תלתן הארגמן"
-    ],
-    "geocoded_locations": {
-      "פארק בריטניה": {
-        "latitude": 31.6982,
-        "longitude": 34.9351
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_76_report_1_class.html"
-  },
-  {
-    "date": "05/04/2015",
-    "observer": "shargil.m",
     "title": "דם-המכבים האדום",
     "description": [
       ""
@@ -109977,28 +102101,6 @@
     "source_file": "tiuli_scraped_reports/page_76_report_1_class.html"
   },
   {
-    "date": "26/03/2015",
-    "observer": "גדי פולק",
-    "title": "יסמין שיחני",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מלכישוע"
-    ],
-    "flowers": [
-      "יסמין שיחני"
-    ],
-    "geocoded_locations": {
-      "מלכישוע": {
-        "latitude": 32.437,
-        "longitude": 35.4138
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_76_report_1_class.html"
-  },
-  {
     "date": "24/03/2015",
     "observer": "Tova3127144",
     "title": "אירוס שחום",
@@ -110059,28 +102161,6 @@
       "תל גמה": {
         "latitude": 31.3871,
         "longitude": 34.4465
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_76_report_1_class.html"
-  },
-  {
-    "date": "23/03/2015",
-    "observer": "אלחי47",
-    "title": "דבורנית צהובה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הכרמל"
-    ],
-    "flowers": [
-      "דבורנית צהובה"
-    ],
-    "geocoded_locations": {
-      "הכרמל": {
-        "latitude": 32.7533,
-        "longitude": 35.0316
       }
     },
     "coordinates": [],
@@ -110773,23 +102853,6 @@
     ],
     "locations": [
       "נחל מחניים עליון"
-    ],
-    "flowers": [
-      "חלמונית גדולה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_178_report_1_class.html"
-  },
-  {
-    "date": "19/11/2007",
-    "observer": "המטייל האנונימי",
-    "title": "חלמונית גדולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שביל פסגה - הר מירון"
     ],
     "flowers": [
       "חלמונית גדולה"
@@ -111851,138 +103914,6 @@
   {
     "date": "13/04/2010",
     "observer": "גדי פולק",
-    "title": "לשון-שור מגובבת",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שדמה - שדה בור"
-    ],
-    "flowers": [
-      "לשון-שור מגובבת"
-    ],
-    "geocoded_locations": {
-      "שדמה - שדה בור": {
-        "latitude": 31.8335,
-        "longitude": 34.7397
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_144_report_1_class.html"
-  },
-  {
-    "date": "13/04/2010",
-    "observer": "גדי פולק",
-    "title": "מצילות החוף",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שדמה - שדה בור"
-    ],
-    "flowers": [
-      "מצילות החוף"
-    ],
-    "geocoded_locations": {
-      "שדמה - שדה בור": {
-        "latitude": 31.8335,
-        "longitude": 34.7397
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_144_report_1_class.html"
-  },
-  {
-    "date": "13/04/2010",
-    "observer": "גדי פולק",
-    "title": "מקור-חסידה מפוצל",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שדמה - שדה בור"
-    ],
-    "flowers": [
-      "מקור-חסידה מפוצל"
-    ],
-    "geocoded_locations": {
-      "שדמה - שדה בור": {
-        "latitude": 31.8335,
-        "longitude": 34.7397
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_144_report_1_class.html"
-  },
-  {
-    "date": "13/04/2010",
-    "observer": "גדי פולק",
-    "title": "עכנאי שרוע",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שדמה - שדה בור"
-    ],
-    "flowers": [
-      "עכנאי שרוע"
-    ],
-    "geocoded_locations": {
-      "שדמה - שדה בור": {
-        "latitude": 31.8335,
-        "longitude": 34.7397
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_144_report_1_class.html"
-  },
-  {
-    "date": "13/04/2010",
-    "observer": "גדי פולק",
-    "title": "פעמונית גפורה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שדמה - שדה בור"
-    ],
-    "flowers": [
-      "פעמונית גפורה"
-    ],
-    "geocoded_locations": {
-      "שדמה - שדה בור": {
-        "latitude": 31.8335,
-        "longitude": 34.7397
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_144_report_1_class.html"
-  },
-  {
-    "date": "13/04/2010",
-    "observer": "גדי פולק",
-    "title": "פרסיון גדול",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שדמה - שדה בור"
-    ],
-    "flowers": [
-      "פרסיון גדול"
-    ],
-    "geocoded_locations": {
-      "שדמה - שדה בור": {
-        "latitude": 31.8335,
-        "longitude": 34.7397
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_144_report_1_class.html"
-  },
-  {
-    "date": "13/04/2010",
-    "observer": "גדי פולק",
     "title": "פרע מסולסל",
     "description": [
       ""
@@ -112476,28 +104407,6 @@
       "מאגר בית ינאי": {
         "latitude": 32.386,
         "longitude": 34.8648
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_75_report_1_class.html"
-  },
-  {
-    "date": "14/04/2015",
-    "observer": "אלחי47",
-    "title": "פשתה מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער עופר"
-    ],
-    "flowers": [
-      "פשתה מצויה"
-    ],
-    "geocoded_locations": {
-      "יער עופר": {
-        "latitude": 32.6514,
-        "longitude": 34.9682
       }
     },
     "coordinates": [],
@@ -114526,23 +106435,6 @@
   {
     "date": "26/01/2013",
     "observer": "עידו מגן",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חרבת מדרס"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_116_report_1_class.html"
-  },
-  {
-    "date": "26/01/2013",
-    "observer": "עידו מגן",
     "title": "שקד מצוי",
     "description": [
       ""
@@ -115087,28 +106979,6 @@
       "השיזף 55, עין ורד, ישראל": {
         "latitude": 32.27273557648073,
         "longitude": 34.928009937113536
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_36_report_1_class.html"
-  },
-  {
-    "date": "04/04/2021",
-    "observer": "חנן - 4135815",
-    "title": "תורמוס ארץ-ישראלי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "השיזף 55, עין ורד, ישראל"
-    ],
-    "flowers": [
-      "תורמוס ארץ-ישראלי"
-    ],
-    "geocoded_locations": {
-      "השיזף 55, עין ורד, ישראל": {
-        "latitude": 32.27239243384986,
-        "longitude": 34.927709155822676
       }
     },
     "coordinates": [],
@@ -116656,28 +108526,6 @@
   },
   {
     "date": "11/01/2022",
-    "observer": "אלחי47",
-    "title": "דבורנית שחומה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "כרמל כביש גבעת וולפסון"
-    ],
-    "flowers": [
-      "דבורנית שחומה"
-    ],
-    "geocoded_locations": {
-      "כרמל כביש גבעת וולפסון": {
-        "latitude": 736834.0,
-        "longitude": 202279.0
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_33_report_1_class.html"
-  },
-  {
-    "date": "11/01/2022",
     "observer": "שמואל65",
     "title": "שמשון סגלגל",
     "description": [
@@ -117021,23 +108869,6 @@
   {
     "date": "02/01/2010",
     "observer": "המטייל האנונימי",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "אזור המוחרקה"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_155_report_1_class.html"
-  },
-  {
-    "date": "02/01/2010",
-    "observer": "המטייל האנונימי",
     "title": "רומולאה סגלולית",
     "description": [
       ""
@@ -117149,23 +108980,6 @@
     ],
     "flowers": [
       "מקור-חסידה מצוי"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_155_report_1_class.html"
-  },
-  {
-    "date": "02/01/2010",
-    "observer": "המטייל האנונימי",
-    "title": "יקינתון מזרחי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הר תורען"
-    ],
-    "flowers": [
-      "יקינתון מזרחי"
     ],
     "geocoded_locations": {},
     "coordinates": [],
@@ -117319,40 +109133,6 @@
     ],
     "flowers": [
       "ציפורנית מצרית"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_155_report_1_class.html"
-  },
-  {
-    "date": "02/01/2010",
-    "observer": "המטייל האנונימי",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל תבור"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_155_report_1_class.html"
-  },
-  {
-    "date": "02/01/2010",
-    "observer": "המטייל האנונימי",
-    "title": "רקפת מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל תבור"
-    ],
-    "flowers": [
-      "רקפת מצויה"
     ],
     "geocoded_locations": {},
     "coordinates": [],
@@ -117531,23 +109311,6 @@
   {
     "date": "26/12/2009",
     "observer": "המטייל האנונימי",
-    "title": "נרקיס מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שמורת אירוס הביצות - אחו נוב"
-    ],
-    "flowers": [
-      "נרקיס מצוי"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_155_report_1_class.html"
-  },
-  {
-    "date": "26/12/2009",
-    "observer": "המטייל האנונימי",
     "title": "ירוקת-חמור מצויה",
     "description": [
       ""
@@ -117591,23 +109354,6 @@
     ],
     "flowers": [
       "דודא רפואי"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_155_report_1_class.html"
-  },
-  {
-    "date": "26/12/2009",
-    "observer": "המטייל האנונימי",
-    "title": "נרקיס מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הר תבור"
-    ],
-    "flowers": [
-      "נרקיס מצוי"
     ],
     "geocoded_locations": {},
     "coordinates": [],
@@ -117684,23 +109430,6 @@
   {
     "date": "26/12/2009",
     "observer": "המטייל האנונימי",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חירבת בורגין"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_155_report_1_class.html"
-  },
-  {
-    "date": "26/12/2009",
-    "observer": "המטייל האנונימי",
     "title": "אירוס ארץ-ישראלי",
     "description": [
       ""
@@ -117727,40 +109456,6 @@
     ],
     "flowers": [
       "זלזלת הקנוקנות"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_155_report_1_class.html"
-  },
-  {
-    "date": "26/12/2009",
-    "observer": "המטייל האנונימי",
-    "title": "דודא רפואי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל עיון - קטע עליון"
-    ],
-    "flowers": [
-      "דודא רפואי"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_155_report_1_class.html"
-  },
-  {
-    "date": "26/12/2009",
-    "observer": "המטייל האנונימי",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל עיון, קטע עליון"
-    ],
-    "flowers": [
-      "כלנית מצויה"
     ],
     "geocoded_locations": {},
     "coordinates": [],
@@ -117945,23 +109640,6 @@
     ],
     "locations": [
       "קרני חיטין"
-    ],
-    "flowers": [
-      "דודא רפואי"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_140_report_1_class.html"
-  },
-  {
-    "date": "25/01/2011",
-    "observer": "המטייל האנונימי",
-    "title": "דודא רפואי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "אגמון החולה"
     ],
     "flowers": [
       "דודא רפואי"
@@ -118305,40 +109983,6 @@
     ],
     "flowers": [
       "כתמה עבת-שורשים"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_140_report_1_class.html"
-  },
-  {
-    "date": "27/12/2010",
-    "observer": "המטייל האנונימי",
-    "title": "כרכום חורפי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "דרך המשלטים בהרי ירושלים מעל שער הגיא"
-    ],
-    "flowers": [
-      "כרכום חורפי"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_140_report_1_class.html"
-  },
-  {
-    "date": "27/12/2010",
-    "observer": "המטייל האנונימי",
-    "title": "כרכום חורפי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "דרך המשלטים בהרי ירושלים מעל שער הגיא"
-    ],
-    "flowers": [
-      "כרכום חורפי"
     ],
     "geocoded_locations": {},
     "coordinates": [],
@@ -119984,50 +111628,6 @@
   {
     "date": "22/02/2018",
     "observer": "עידו מגן",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חורבת שוכה - גבעת התורמוסים"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "חורבת שוכה - גבעת התורמוסים": {
-        "latitude": 31.682023,
-        "longitude": 34.97413400000005
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_58_report_1_class.html"
-  },
-  {
-    "date": "22/02/2018",
-    "observer": "עידו מגן",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חורבת שוכה - גבעת התורמוסים"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "חורבת שוכה - גבעת התורמוסים": {
-        "latitude": 31.682023,
-        "longitude": 34.97413400000005
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_58_report_1_class.html"
-  },
-  {
-    "date": "22/02/2018",
-    "observer": "עידו מגן",
     "title": "תורמוס ההרים",
     "description": [
       ""
@@ -120072,50 +111672,6 @@
   {
     "date": "22/02/2018",
     "observer": "עידו מגן",
-    "title": "צהרון מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "אנדרטת מגילת האש"
-    ],
-    "flowers": [
-      "צהרון מצוי"
-    ],
-    "geocoded_locations": {
-      "אנדרטת מגילת האש": {
-        "latitude": 31.7724282,
-        "longitude": 35.04427809999993
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_58_report_1_class.html"
-  },
-  {
-    "date": "22/02/2018",
-    "observer": "עידו מגן",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "אנדרטת מגילת האש"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "אנדרטת מגילת האש": {
-        "latitude": 31.7724282,
-        "longitude": 35.04427809999993
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_58_report_1_class.html"
-  },
-  {
-    "date": "22/02/2018",
-    "observer": "עידו מגן",
     "title": "צבעוני ההרים",
     "description": [
       ""
@@ -120125,28 +111681,6 @@
     ],
     "flowers": [
       "צבעוני ההרים"
-    ],
-    "geocoded_locations": {
-      "אנדרטת מגילת האש": {
-        "latitude": 31.7724282,
-        "longitude": 35.04427809999993
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_58_report_1_class.html"
-  },
-  {
-    "date": "22/02/2018",
-    "observer": "עידו מגן",
-    "title": "רקפת מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "אנדרטת מגילת האש"
-    ],
-    "flowers": [
-      "רקפת מצויה"
     ],
     "geocoded_locations": {
       "אנדרטת מגילת האש": {
@@ -120204,28 +111738,6 @@
   {
     "date": "16/02/2018",
     "observer": "עידו מגן",
-    "title": "כליל החורש",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק עצמאות ארה\"ב"
-    ],
-    "flowers": [
-      "כליל החורש"
-    ],
-    "geocoded_locations": {
-      "פארק עצמאות ארה\"ב": {
-        "latitude": 31.74554,
-        "longitude": 35.03829799999994
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_58_report_1_class.html"
-  },
-  {
-    "date": "16/02/2018",
-    "observer": "עידו מגן",
     "title": "שקד מצוי",
     "description": [
       ""
@@ -120240,50 +111752,6 @@
       "חורבת נכס, מודיעין מכבים רעות": {
         "latitude": 31.890267,
         "longitude": 35.01039700000001
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_58_report_1_class.html"
-  },
-  {
-    "date": "16/02/2018",
-    "observer": "עידו מגן",
-    "title": "שקד מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "סטף, צובה"
-    ],
-    "flowers": [
-      "שקד מצוי"
-    ],
-    "geocoded_locations": {
-      "סטף, צובה": {
-        "latitude": 31.771742,
-        "longitude": 35.127655600000026
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_58_report_1_class.html"
-  },
-  {
-    "date": "16/02/2018",
-    "observer": "עידו מגן",
-    "title": "שקד מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מיני ישראל"
-    ],
-    "flowers": [
-      "שקד מצוי"
-    ],
-    "geocoded_locations": {
-      "מיני ישראל": {
-        "latitude": 31.8421649,
-        "longitude": 34.969015799999966
       }
     },
     "coordinates": [],
@@ -120372,72 +111840,6 @@
       "פארק עצמאות ארה\"ב": {
         "latitude": 31.74554,
         "longitude": 35.03829799999994
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_58_report_1_class.html"
-  },
-  {
-    "date": "16/02/2018",
-    "observer": "עידו מגן",
-    "title": "רקפת מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מנזר לטרון"
-    ],
-    "flowers": [
-      "רקפת מצויה"
-    ],
-    "geocoded_locations": {
-      "מנזר לטרון": {
-        "latitude": 31.832722,
-        "longitude": 34.97981000000004
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_58_report_1_class.html"
-  },
-  {
-    "date": "16/02/2018",
-    "observer": "עידו מגן",
-    "title": "רקפת מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "סטף, צובה"
-    ],
-    "flowers": [
-      "רקפת מצויה"
-    ],
-    "geocoded_locations": {
-      "סטף, צובה": {
-        "latitude": 31.771742,
-        "longitude": 35.127655600000026
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_58_report_1_class.html"
-  },
-  {
-    "date": "16/02/2018",
-    "observer": "עידו מגן",
-    "title": "רקפת מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חורבת נכס, מודיעין מכבים רעות"
-    ],
-    "flowers": [
-      "רקפת מצויה"
-    ],
-    "geocoded_locations": {
-      "חורבת נכס, מודיעין מכבים רעות": {
-        "latitude": 31.88939248950929,
-        "longitude": 35.009817642852795
       }
     },
     "coordinates": [],
@@ -120636,28 +112038,6 @@
       "קבר אריאל ולילי שרון - גבעת הכלניות, אזור אשקלון": {
         "latitude": 31.513983681231554,
         "longitude": 34.64096546173096
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_58_report_1_class.html"
-  },
-  {
-    "date": "05/02/2018",
-    "observer": "עידו מגן",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער שוקדה, שוקדה"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "יער שוקדה, שוקדה": {
-        "latitude": 31.43210526236488,
-        "longitude": 34.51779842376709
       }
     },
     "coordinates": [],
@@ -121414,23 +112794,6 @@
   {
     "date": "05/12/2009",
     "observer": "המטייל האנונימי",
-    "title": "כרכום חורפי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "רמת הנדיב"
-    ],
-    "flowers": [
-      "כרכום חורפי"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_156_report_1_class.html"
-  },
-  {
-    "date": "05/12/2009",
-    "observer": "המטייל האנונימי",
     "title": "ציפורני-חתול מצויות",
     "description": [
       ""
@@ -121702,28 +113065,6 @@
   {
     "date": "30/01/2018",
     "observer": "עידו מגן",
-    "title": "רקפת מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חורבת מדרס, שפלת יהודה"
-    ],
-    "flowers": [
-      "רקפת מצויה"
-    ],
-    "geocoded_locations": {
-      "חורבת מדרס, שפלת יהודה": {
-        "latitude": 31.654773,
-        "longitude": 34.93902600000001
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_59_report_1_class.html"
-  },
-  {
-    "date": "30/01/2018",
-    "observer": "עידו מגן",
     "title": "כלנית מצויה",
     "description": [
       ""
@@ -121738,50 +113079,6 @@
       "גבעת התיתורה, דרך יגאל אלון, מודיעין מכבים רעות": {
         "latitude": 31.908273794239914,
         "longitude": 35.024070739746094
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_59_report_1_class.html"
-  },
-  {
-    "date": "30/01/2018",
-    "observer": "עידו מגן",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "גבעת התיתורה, דרך יגאל אלון, מודיעין מכבים רעות"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "גבעת התיתורה, דרך יגאל אלון, מודיעין מכבים רעות": {
-        "latitude": 31.89497565106021,
-        "longitude": 35.02286911010742
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_59_report_1_class.html"
-  },
-  {
-    "date": "30/01/2018",
-    "observer": "עידו מגן",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חורבת מדרס, שפלת יהודה"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "חורבת מדרס, שפלת יהודה": {
-        "latitude": 31.648961020806176,
-        "longitude": 34.94420528411865
       }
     },
     "coordinates": [],
@@ -121848,28 +113145,6 @@
       "בית שערים": {
         "latitude": 32.703316675523716,
         "longitude": 35.17393112182617
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_59_report_1_class.html"
-  },
-  {
-    "date": "13/01/2018",
-    "observer": "עידו מגן",
-    "title": "רקפת מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שמורת אלוני יצחק"
-    ],
-    "flowers": [
-      "רקפת מצויה"
-    ],
-    "geocoded_locations": {
-      "שמורת אלוני יצחק": {
-        "latitude": 32.51262074036335,
-        "longitude": 35.00613212585449
       }
     },
     "coordinates": [],
@@ -121986,28 +113261,6 @@
     "source_file": "tiuli_scraped_reports/page_59_report_1_class.html"
   },
   {
-    "date": "30/12/2017",
-    "observer": "עידו מגן",
-    "title": "רקפת מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "אנדרטת חטיבת ברק"
-    ],
-    "flowers": [
-      "רקפת מצויה"
-    ],
-    "geocoded_locations": {
-      "אנדרטת חטיבת ברק": {
-        "latitude": 31.839877,
-        "longitude": 34.97914100000003
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_59_report_1_class.html"
-  },
-  {
     "date": "29/12/2017",
     "observer": "רונזולה",
     "title": "נרקיס מצוי",
@@ -122046,28 +113299,6 @@
       "שמורת נחל דליה ויובליו, אזור זכרון יעקב": {
         "latitude": 32.590791901737894,
         "longitude": 35.01497268676758
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_59_report_1_class.html"
-  },
-  {
-    "date": "16/12/2017",
-    "observer": "עידו מגן",
-    "title": "כרכום חורפי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "קרן הכרמל, אזור חיפה"
-    ],
-    "flowers": [
-      "כרכום חורפי"
-    ],
-    "geocoded_locations": {
-      "קרן הכרמל, אזור חיפה": {
-        "latitude": 32.674205348845035,
-        "longitude": 35.094194412231445
       }
     },
     "coordinates": [],
@@ -122228,28 +113459,6 @@
     "source_file": "tiuli_scraped_reports/page_59_report_1_class.html"
   },
   {
-    "date": "26/11/2017",
-    "observer": "עידו מגן",
-    "title": "רקפת מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חורשת הארבעים, נשר"
-    ],
-    "flowers": [
-      "רקפת מצויה"
-    ],
-    "geocoded_locations": {
-      "חורשת הארבעים, נשר": {
-        "latitude": 32.7545185,
-        "longitude": 35.02925959999993
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_59_report_1_class.html"
-  },
-  {
     "date": "25/11/2017",
     "observer": "עידו מגן",
     "title": "נרקיס מצוי",
@@ -122354,138 +113563,6 @@
       "מרום גולן": {
         "latitude": 33.132583,
         "longitude": 35.77707099999998
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_59_report_1_class.html"
-  },
-  {
-    "date": "21/10/2017",
-    "observer": "ysamid",
-    "title": "סתוונית התשבץ",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מרום גולן"
-    ],
-    "flowers": [
-      "סתוונית התשבץ"
-    ],
-    "geocoded_locations": {
-      "מרום גולן": {
-        "latitude": 33.132583,
-        "longitude": 35.77707099999998
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_59_report_1_class.html"
-  },
-  {
-    "date": "21/10/2017",
-    "observer": "ysamid",
-    "title": "סתוונית התשבץ",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מרום גולן"
-    ],
-    "flowers": [
-      "סתוונית התשבץ"
-    ],
-    "geocoded_locations": {
-      "מרום גולן": {
-        "latitude": 33.1338767459957,
-        "longitude": 35.76737213220213
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_59_report_1_class.html"
-  },
-  {
-    "date": "21/10/2017",
-    "observer": "ysamid",
-    "title": "סתוונית התשבץ",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "סינגל מרום גולן"
-    ],
-    "flowers": [
-      "סתוונית התשבץ"
-    ],
-    "geocoded_locations": {
-      "סינגל מרום גולן": {
-        "latitude": 33.13405643143148,
-        "longitude": 35.76784420098875
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_59_report_1_class.html"
-  },
-  {
-    "date": "21/10/2017",
-    "observer": "ysamid",
-    "title": "סתוונית התשבץ",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מרום גולן"
-    ],
-    "flowers": [
-      "סתוונית התשבץ"
-    ],
-    "geocoded_locations": {
-      "מרום גולן": {
-        "latitude": 33.13243924926791,
-        "longitude": 35.769131661315896
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_59_report_1_class.html"
-  },
-  {
-    "date": "21/10/2017",
-    "observer": "ysamid",
-    "title": "סתוונית התשבץ",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "בסינגל מרום גולן"
-    ],
-    "flowers": [
-      "סתוונית התשבץ"
-    ],
-    "geocoded_locations": {
-      "בסינגל מרום גולן": {
-        "latitude": 272149.0,
-        "longitude": 782152.0
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_59_report_1_class.html"
-  },
-  {
-    "date": "21/10/2017",
-    "observer": "יוחאי כורם",
-    "title": "נרקיס סתווי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "ניל תנינים"
-    ],
-    "flowers": [
-      "נרקיס סתווי"
-    ],
-    "geocoded_locations": {
-      "ניל תנינים": {
-        "latitude": 32.549218817513335,
-        "longitude": 34.914658069610596
       }
     },
     "coordinates": [],
@@ -122606,23 +113683,6 @@
   {
     "date": "01/03/2008",
     "observer": "המטייל האנונימי",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חרבת חנות ועין מטע"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_175_report_1_class.html"
-  },
-  {
-    "date": "01/03/2008",
-    "observer": "המטייל האנונימי",
     "title": "אירוס הארגמן",
     "description": [
       ""
@@ -122632,23 +113692,6 @@
     ],
     "flowers": [
       "אירוס הארגמן"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_175_report_1_class.html"
-  },
-  {
-    "date": "01/03/2008",
-    "observer": "המטייל האנונימי",
-    "title": "תורמוס ההרים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "בריכת הג'מוסים - בלפוריה"
-    ],
-    "flowers": [
-      "תורמוס ההרים"
     ],
     "geocoded_locations": {},
     "coordinates": [],
@@ -123902,28 +114945,6 @@
     "source_file": "tiuli_scraped_reports/page_73_report_1_class.html"
   },
   {
-    "date": "14/11/2015",
-    "observer": "המטייל האנונימי",
-    "title": "חלמונית גדולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שביל החלמוניות יער ביריה"
-    ],
-    "flowers": [
-      "חלמונית גדולה"
-    ],
-    "geocoded_locations": {
-      "שביל החלמוניות יער ביריה": {
-        "latitude": 32.994,
-        "longitude": 35.5312
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_73_report_1_class.html"
-  },
-  {
     "date": "07/11/2015",
     "observer": "המטייל האנונימי",
     "title": "רקפת מצויה",
@@ -124386,28 +115407,6 @@
     "source_file": "tiuli_scraped_reports/page_73_report_1_class.html"
   },
   {
-    "date": "15/06/2015",
-    "observer": "יוחאי כורם",
-    "title": "אלמוות הכסף",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "קיסריה"
-    ],
-    "flowers": [
-      "אלמוות הכסף"
-    ],
-    "geocoded_locations": {
-      "קיסריה": {
-        "latitude": 32.5,
-        "longitude": 34.8
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_73_report_1_class.html"
-  },
-  {
     "date": "14/04/2017",
     "observer": "אלחי47",
     "title": "אדמונית החורש",
@@ -124666,28 +115665,6 @@
       "הכרמל": {
         "latitude": 32.7415,
         "longitude": 35.0728
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_61_report_1_class.html"
-  },
-  {
-    "date": "07/04/2017",
-    "observer": "אלחי47",
-    "title": "בן-חצב יקינתוני",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הכרמל-נחל מעפילים"
-    ],
-    "flowers": [
-      "בן-חצב יקינתוני"
-    ],
-    "geocoded_locations": {
-      "הכרמל-נחל מעפילים": {
-        "latitude": 32.7367,
-        "longitude": 35.0749
       }
     },
     "coordinates": [],
@@ -125114,28 +116091,6 @@
   {
     "date": "01/04/2017",
     "observer": "אלחי47",
-    "title": "אירוס החרמון",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הגולן קבר שייח מרזוק"
-    ],
-    "flowers": [
-      "אירוס החרמון"
-    ],
-    "geocoded_locations": {
-      "הגולן קבר שייח מרזוק": {
-        "latitude": 33.0504,
-        "longitude": 35.7006
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_61_report_1_class.html"
-  },
-  {
-    "date": "01/04/2017",
-    "observer": "אלחי47",
     "title": "ארבע-כנפות מצויות",
     "description": [
       ""
@@ -125260,50 +116215,6 @@
       "שמורת טבע ופארק רמת הנדיב": {
         "latitude": 32.5477,
         "longitude": 34.9421
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_61_report_1_class.html"
-  },
-  {
-    "date": "29/03/2017",
-    "observer": "Talia_nature",
-    "title": "סיפן התבואה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל מערות - המסלול הכחול וסביבתו"
-    ],
-    "flowers": [
-      "סיפן התבואה"
-    ],
-    "geocoded_locations": {
-      "נחל מערות - המסלול הכחול וסביבתו": {
-        "latitude": 32.6707,
-        "longitude": 34.9662
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_61_report_1_class.html"
-  },
-  {
-    "date": "29/03/2017",
-    "observer": "Talia_nature",
-    "title": "בן-חצב יקינתוני",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל מערות - המסלול הכחול וסביבתו"
-    ],
-    "flowers": [
-      "בן-חצב יקינתוני"
-    ],
-    "geocoded_locations": {
-      "נחל מערות - המסלול הכחול וסביבתו": {
-        "latitude": 32.6707,
-        "longitude": 34.9662
       }
     },
     "coordinates": [],
@@ -126037,50 +116948,6 @@
   },
   {
     "date": "07/01/2017",
-    "observer": "Iddo_3270859",
-    "title": "רקפת מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק בריטניה"
-    ],
-    "flowers": [
-      "רקפת מצויה"
-    ],
-    "geocoded_locations": {
-      "פארק בריטניה": {
-        "latitude": 31.699,
-        "longitude": 34.9279
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_67_report_1_class.html"
-  },
-  {
-    "date": "07/01/2017",
-    "observer": "Iddo_3270859",
-    "title": "רקפת מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק בריטניה"
-    ],
-    "flowers": [
-      "רקפת מצויה"
-    ],
-    "geocoded_locations": {
-      "פארק בריטניה": {
-        "latitude": 31.699,
-        "longitude": 34.9279
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_67_report_1_class.html"
-  },
-  {
-    "date": "07/01/2017",
     "observer": "Naomi_3368594",
     "title": "נרקיס מצוי",
     "description": [
@@ -126140,28 +117007,6 @@
       "שלוחת נחל יגור": {
         "latitude": 32.7362,
         "longitude": 35.0741
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_67_report_1_class.html"
-  },
-  {
-    "date": "07/01/2017",
-    "observer": "המטייל האנונימי",
-    "title": "אירוס ארץ-ישראלי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חורבת חנות"
-    ],
-    "flowers": [
-      "אירוס ארץ-ישראלי"
-    ],
-    "geocoded_locations": {
-      "חורבת חנות": {
-        "latitude": 31.7121,
-        "longitude": 35.0463
       }
     },
     "coordinates": [],
@@ -126432,50 +117277,6 @@
     "source_file": "tiuli_scraped_reports/page_67_report_1_class.html"
   },
   {
-    "date": "10/12/2016",
-    "observer": "המטייל האנונימי",
-    "title": "אירוס הסרגל",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "ליד מצפור קרן כרמל"
-    ],
-    "flowers": [
-      "אירוס הסרגל"
-    ],
-    "geocoded_locations": {
-      "ליד מצפור קרן כרמל": {
-        "latitude": 32.6485,
-        "longitude": 35.0722
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_67_report_1_class.html"
-  },
-  {
-    "date": "26/11/2016",
-    "observer": "אלחי47",
-    "title": "חלמונית גדולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הגלבוע"
-    ],
-    "flowers": [
-      "חלמונית גדולה"
-    ],
-    "geocoded_locations": {
-      "הגלבוע": {
-        "latitude": 32.4138,
-        "longitude": 35.4152
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_67_report_1_class.html"
-  },
-  {
     "date": "26/11/2016",
     "observer": "אלחי47",
     "title": "חלמונית גדולה",
@@ -126632,28 +117433,6 @@
   {
     "date": "19/04/2020",
     "observer": "Tamar3213448",
-    "title": "דם-המכבים האדום",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "גת ביזנטית, כביש אורה, ירושלים"
-    ],
-    "flowers": [
-      "דם-המכבים האדום"
-    ],
-    "geocoded_locations": {
-      "גת ביזנטית, כביש אורה, ירושלים": {
-        "latitude": 31.7560569,
-        "longitude": 35.1617561
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_48_report_1_class.html"
-  },
-  {
-    "date": "19/04/2020",
-    "observer": "Tamar3213448",
     "title": "לשון-שור מגובבת",
     "description": [
       ""
@@ -126734,28 +117513,6 @@
       "115, עין יעקב, ישראל": {
         "latitude": 33.0123353,
         "longitude": 35.2317032
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_48_report_1_class.html"
-  },
-  {
-    "date": "02/04/2020",
-    "observer": "Boyarin Helena_4108498",
-    "title": "עיריוני צהוב",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "קרית ארבע"
-    ],
-    "flowers": [
-      "עיריוני צהוב"
-    ],
-    "geocoded_locations": {
-      "קרית ארבע": {
-        "latitude": 31.52517828753679,
-        "longitude": 35.105652809143066
       }
     },
     "coordinates": [],
@@ -127292,50 +118049,6 @@
   {
     "date": "19/03/2020",
     "observer": "אלחי47",
-    "title": "פשתנית יפו",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "דרך גבעות הכורכר, נס ציונה"
-    ],
-    "flowers": [
-      "פשתנית יפו"
-    ],
-    "geocoded_locations": {
-      "דרך גבעות הכורכר, נס ציונה": {
-        "latitude": 649354.0,
-        "longitude": 179850.0
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_48_report_1_class.html"
-  },
-  {
-    "date": "19/03/2020",
-    "observer": "אלחי47",
-    "title": "פשתנית יפו",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הגן הלאומי גבעות הכורכר נס ציונה, דרך גבעות הכורכר, נס ציונה"
-    ],
-    "flowers": [
-      "פשתנית יפו"
-    ],
-    "geocoded_locations": {
-      "הגן הלאומי גבעות הכורכר נס ציונה, דרך גבעות הכורכר, נס ציונה": {
-        "latitude": 649286.0,
-        "longitude": 179908.0
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_48_report_1_class.html"
-  },
-  {
-    "date": "19/03/2020",
-    "observer": "אלחי47",
     "title": "סחלב דינסמור",
     "description": [
       ""
@@ -127372,28 +118085,6 @@
       "חדרה": {
         "latitude": 32.419234146251824,
         "longitude": 34.92057362648586
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_48_report_1_class.html"
-  },
-  {
-    "date": "18/03/2020",
-    "observer": "אלחי47",
-    "title": "גולנית ערב",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "בור חמת"
-    ],
-    "flowers": [
-      "גולנית ערב"
-    ],
-    "geocoded_locations": {
-      "בור חמת": {
-        "latitude": 500077.0,
-        "longitude": 172122.0
       }
     },
     "coordinates": [],
@@ -127554,28 +118245,6 @@
     "source_file": "tiuli_scraped_reports/page_48_report_1_class.html"
   },
   {
-    "date": "17/03/2020",
-    "observer": "Iddo_3270859",
-    "title": "נורית אסיה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל קטלב"
-    ],
-    "flowers": [
-      "נורית אסיה"
-    ],
-    "geocoded_locations": {
-      "נחל קטלב": {
-        "latitude": 31.73712600000001,
-        "longitude": 35.077726
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_48_report_1_class.html"
-  },
-  {
     "date": "04/03/2007",
     "observer": "המטייל האנונימי",
     "title": "טופח ריסני",
@@ -127703,23 +118372,6 @@
     ],
     "locations": [
       "שמורת האירוסים נתניה"
-    ],
-    "flowers": [
-      "תורמוס ארץ-ישראלי"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_186_report_1_class.html"
-  },
-  {
-    "date": "04/03/2007",
-    "observer": "יוחאי כורם",
-    "title": "תורמוס ארץ-ישראלי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שמורת קדימה"
     ],
     "flowers": [
       "תורמוס ארץ-ישראלי"
@@ -128196,23 +118848,6 @@
     ],
     "locations": [
       "שמורת האירוסים בנתניה"
-    ],
-    "flowers": [
-      "אירוס הארגמן"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_186_report_1_class.html"
-  },
-  {
-    "date": "03/03/2007",
-    "observer": "יוחאי כורם",
-    "title": "אירוס הארגמן",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שמורת קדימה - השרון"
     ],
     "flowers": [
       "אירוס הארגמן"
@@ -129367,28 +120002,6 @@
   },
   {
     "date": "09/03/2024",
-    "observer": "urga41",
-    "title": "לוף מנומר",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חורשת הסרג'נטים/האוניברסיטה, נתניה, ישראל"
-    ],
-    "flowers": [
-      "לוף מנומר"
-    ],
-    "geocoded_locations": {
-      "חורשת הסרג'נטים/האוניברסיטה, נתניה, ישראל": {
-        "latitude": 32.30490918773771,
-        "longitude": 34.87789008888551
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_5_report_1_class.html"
-  },
-  {
-    "date": "09/03/2024",
     "observer": "Iddo_3270859",
     "title": "דבורנית דינסמור",
     "description": [
@@ -129500,28 +120113,6 @@
   {
     "date": "09/03/2024",
     "observer": "Iddo_3270859",
-    "title": "רקפת מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "אנדרטת מגילת האש"
-    ],
-    "flowers": [
-      "רקפת מצויה"
-    ],
-    "geocoded_locations": {
-      "אנדרטת מגילת האש": {
-        "latitude": 31.77242820000001,
-        "longitude": 35.0442781
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_5_report_1_class.html"
-  },
-  {
-    "date": "09/03/2024",
-    "observer": "Iddo_3270859",
     "title": "צבעוני ההרים",
     "description": [
       ""
@@ -129536,28 +120127,6 @@
       "חרמון, מבשרת ציון": {
         "latitude": 31.80839799999999,
         "longitude": 35.15007
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_5_report_1_class.html"
-  },
-  {
-    "date": "09/03/2024",
-    "observer": "Iddo_3270859",
-    "title": "צבעוני ההרים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק בריכת החורף"
-    ],
-    "flowers": [
-      "צבעוני ההרים"
-    ],
-    "geocoded_locations": {
-      "פארק בריכת החורף": {
-        "latitude": 32.2719919,
-        "longitude": 34.927532
       }
     },
     "coordinates": [],
@@ -129751,28 +120320,6 @@
     ],
     "flowers": [
       "צבעוני ההרים"
-    ],
-    "geocoded_locations": {
-      "אנדרטת מגילת האש": {
-        "latitude": 31.77242820000001,
-        "longitude": 35.0442781
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_5_report_1_class.html"
-  },
-  {
-    "date": "08/03/2024",
-    "observer": "Iddo_3270859",
-    "title": "סחלב הגליל",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "אנדרטת מגילת האש"
-    ],
-    "flowers": [
-      "סחלב הגליל"
     ],
     "geocoded_locations": {
       "אנדרטת מגילת האש": {
@@ -130006,50 +120553,6 @@
   {
     "date": "02/03/2024",
     "observer": "Iddo_3270859",
-    "title": "רקפת מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "אנדרטת מגילת האש"
-    ],
-    "flowers": [
-      "רקפת מצויה"
-    ],
-    "geocoded_locations": {
-      "אנדרטת מגילת האש": {
-        "latitude": 31.77242820000001,
-        "longitude": 35.0442781
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_5_report_1_class.html"
-  },
-  {
-    "date": "02/03/2024",
-    "observer": "Iddo_3270859",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מאגר בית זית, בית זית"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "מאגר בית זית, בית זית": {
-        "latitude": 31.779255966611547,
-        "longitude": 35.1568494821002
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_5_report_1_class.html"
-  },
-  {
-    "date": "02/03/2024",
-    "observer": "Iddo_3270859",
     "title": "צבעוני ההרים",
     "description": [
       ""
@@ -130116,28 +120619,6 @@
   {
     "date": "01/03/2024",
     "observer": "Iddo_3270859",
-    "title": "שקד מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מבוא חורון"
-    ],
-    "flowers": [
-      "שקד מצוי"
-    ],
-    "geocoded_locations": {
-      "מבוא חורון": {
-        "latitude": 31.849598,
-        "longitude": 35.034977
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_5_report_1_class.html"
-  },
-  {
-    "date": "01/03/2024",
-    "observer": "Iddo_3270859",
     "title": "צהרון מצוי",
     "description": [
       ""
@@ -130152,28 +120633,6 @@
       "מבוא חורון": {
         "latitude": 31.849598,
         "longitude": 35.034977
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_5_report_1_class.html"
-  },
-  {
-    "date": "01/03/2024",
-    "observer": "Iddo_3270859",
-    "title": "צהרון מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חורבת שרישה"
-    ],
-    "flowers": [
-      "צהרון מצוי"
-    ],
-    "geocoded_locations": {
-      "חורבת שרישה": {
-        "latitude": 31.821855,
-        "longitude": 34.939473
       }
     },
     "coordinates": [],
@@ -130196,28 +120655,6 @@
       "חורבת שרישה": {
         "latitude": 31.821855,
         "longitude": 34.939473
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_5_report_1_class.html"
-  },
-  {
-    "date": "01/03/2024",
-    "observer": "Iddo_3270859",
-    "title": "שקד מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחשון"
-    ],
-    "flowers": [
-      "שקד מצוי"
-    ],
-    "geocoded_locations": {
-      "נחשון": {
-        "latitude": 31.831616,
-        "longitude": 34.955986
       }
     },
     "coordinates": [],
@@ -131439,23 +121876,6 @@
     "source_file": "tiuli_scraped_reports/page_167_report_1_class.html"
   },
   {
-    "date": "23/01/2009",
-    "observer": "המטייל האנונימי",
-    "title": "אירוס ארץ-ישראלי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שמורת בני ציון"
-    ],
-    "flowers": [
-      "אירוס ארץ-ישראלי"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_167_report_1_class.html"
-  },
-  {
     "date": "19/01/2009",
     "observer": "ff28",
     "title": "לוטם מרווני",
@@ -131577,23 +121997,6 @@
   {
     "date": "13/01/2009",
     "observer": "המטייל האנונימי",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "גבעת הכלניות"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_167_report_1_class.html"
-  },
-  {
-    "date": "13/01/2009",
-    "observer": "המטייל האנונימי",
     "title": "רקפת מצויה",
     "description": [
       ""
@@ -131651,23 +122054,6 @@
     ],
     "locations": [
       "הר זיו, מעל נחל כזיב"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_167_report_1_class.html"
-  },
-  {
-    "date": "12/01/2009",
-    "observer": "המטייל האנונימי",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "ליד כפר בן-נון"
     ],
     "flowers": [
       "כלנית מצויה"
@@ -131798,46 +122184,12 @@
   {
     "date": "03/01/2009",
     "observer": "המטייל האנונימי",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שמורת אלוני יצחק"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_167_report_1_class.html"
-  },
-  {
-    "date": "03/01/2009",
-    "observer": "המטייל האנונימי",
     "title": "רקפת מצויה",
     "description": [
       ""
     ],
     "locations": [
       "רמת הנדיב  - שביל אדום"
-    ],
-    "flowers": [
-      "רקפת מצויה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_167_report_1_class.html"
-  },
-  {
-    "date": "03/01/2009",
-    "observer": "המטייל האנונימי",
-    "title": "רקפת מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שמורת אלוני יצחק"
     ],
     "flowers": [
       "רקפת מצויה"
@@ -132230,28 +122582,6 @@
     "source_file": "tiuli_scraped_reports/page_20_report_1_class.html"
   },
   {
-    "date": "24/01/2023",
-    "observer": "Iddo_3270859",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שמורת עין אפק, אפק"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "שמורת עין אפק, אפק": {
-        "latitude": 32.838316,
-        "longitude": 35.12778
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_20_report_1_class.html"
-  },
-  {
     "date": "23/01/2023",
     "observer": "ניר_4166456",
     "title": "כלנית מצויה",
@@ -132430,28 +122760,6 @@
   {
     "date": "20/01/2023",
     "observer": "אלחי47",
-    "title": "סתוונית הנגב",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק תעשייה עומר, עומרים, עומר"
-    ],
-    "flowers": [
-      "סתוונית הנגב"
-    ],
-    "geocoded_locations": {
-      "פארק תעשייה עומר, עומרים, עומר": {
-        "latitude": 31.275,
-        "longitude": 34.839
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_20_report_1_class.html"
-  },
-  {
-    "date": "20/01/2023",
-    "observer": "אלחי47",
     "title": "סחלב השקיק",
     "description": [
       ""
@@ -132532,28 +122840,6 @@
       "יער הקדושים": {
         "latitude": 31.780806,
         "longitude": 35.061326
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_20_report_1_class.html"
-  },
-  {
-    "date": "20/01/2023",
-    "observer": "Iddo_3270859",
-    "title": "רקפת מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער הקדושים"
-    ],
-    "flowers": [
-      "רקפת מצויה"
-    ],
-    "geocoded_locations": {
-      "יער הקדושים": {
-        "latitude": 31.78365196716833,
-        "longitude": 35.06108028991091
       }
     },
     "coordinates": [],
@@ -132707,28 +122993,6 @@
     "geocoded_locations": {
       "אתר פיקניק חניון הצוק, חיפה": {
         "latitude": 32.745,
-        "longitude": 35.027
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_20_report_1_class.html"
-  },
-  {
-    "date": "18/01/2023",
-    "observer": "אלחי47",
-    "title": "רומולאה צידונית",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "אתר פיקניק חניון הצוק, חיפה"
-    ],
-    "flowers": [
-      "רומולאה צידונית"
-    ],
-    "geocoded_locations": {
-      "אתר פיקניק חניון הצוק, חיפה": {
-        "latitude": 32.744,
         "longitude": 35.027
       }
     },
@@ -133058,46 +123322,12 @@
   {
     "date": "22/03/2007",
     "observer": "המטייל האנונימי",
-    "title": "אירוס שחום",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער הדודאים קצת צפונה לבאר שבע"
-    ],
-    "flowers": [
-      "אירוס שחום"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_184_report_1_class.html"
-  },
-  {
-    "date": "22/03/2007",
-    "observer": "המטייל האנונימי",
     "title": "פשתה שעירה",
     "description": [
       ""
     ],
     "locations": [
       "פארק קנדה ליד לטרון"
-    ],
-    "flowers": [
-      "פשתה שעירה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_184_report_1_class.html"
-  },
-  {
-    "date": "22/03/2007",
-    "observer": "המטייל האנונימי",
-    "title": "פשתה שעירה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער יהדות תימן"
     ],
     "flowers": [
       "פשתה שעירה"
@@ -133277,40 +123507,6 @@
     "source_file": "tiuli_scraped_reports/page_184_report_1_class.html"
   },
   {
-    "date": "19/03/2007",
-    "observer": "המטייל האנונימי",
-    "title": "אירוס החרמון",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "תל אבל בית מעכה"
-    ],
-    "flowers": [
-      "אירוס החרמון"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_184_report_1_class.html"
-  },
-  {
-    "date": "19/03/2007",
-    "observer": "המטייל האנונימי",
-    "title": "אירוס החרמון",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "צפוניתלקרית שמונה ליד כביש 90"
-    ],
-    "flowers": [
-      "אירוס החרמון"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_184_report_1_class.html"
-  },
-  {
     "date": "18/03/2007",
     "observer": "המטייל האנונימי",
     "title": "הרדופנין יהודה",
@@ -133356,23 +123552,6 @@
     ],
     "flowers": [
       "צהרון מצוי"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_184_report_1_class.html"
-  },
-  {
-    "date": "18/03/2007",
-    "observer": "המטייל האנונימי",
-    "title": "בן-פרג סגול",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שמורת אירוס ירוחם"
-    ],
-    "flowers": [
-      "בן-פרג סגול"
     ],
     "geocoded_locations": {},
     "coordinates": [],
@@ -133523,23 +123702,6 @@
     ],
     "locations": [
       "תל ערד"
-    ],
-    "flowers": [
-      "אירוס שחום"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_184_report_1_class.html"
-  },
-  {
-    "date": "17/03/2007",
-    "observer": "המטייל האנונימי",
-    "title": "אירוס שחום",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "על צידו הצפוני של כביש עוקף באר שבע סמוך לצומת גורל"
     ],
     "flowers": [
       "אירוס שחום"
@@ -133781,23 +123943,6 @@
     ],
     "flowers": [
       "הרדופנין הציצית"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_184_report_1_class.html"
-  },
-  {
-    "date": "12/03/2007",
-    "observer": "המטייל האנונימי",
-    "title": "כלך מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "גלבוע , גבעת האירוסים"
-    ],
-    "flowers": [
-      "כלך מצוי"
     ],
     "geocoded_locations": {},
     "coordinates": [],
@@ -135086,23 +125231,6 @@
     "source_file": "tiuli_scraped_reports/page_142_report_1_class.html"
   },
   {
-    "date": "01/05/2010",
-    "observer": "המטייל האנונימי",
-    "title": "שושן צחור",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל כזיב - קרן ברתות"
-    ],
-    "flowers": [
-      "שושן צחור"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_142_report_1_class.html"
-  },
-  {
     "date": "24/04/2010",
     "observer": "המטייל האנונימי",
     "title": "שושן צחור",
@@ -135917,23 +126045,6 @@
   },
   {
     "date": "31/03/2013",
-    "observer": "אלחי47",
-    "title": "דבורנית נאה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "בכביש לשביל הפיסגה במירון"
-    ],
-    "flowers": [
-      "דבורנית נאה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_108_report_1_class.html"
-  },
-  {
-    "date": "31/03/2013",
     "observer": "yonatbe5",
     "title": "אירוס החרמון",
     "description": [
@@ -136730,28 +126841,6 @@
   {
     "date": "20/04/2014",
     "observer": "גדי פולק",
-    "title": "דמסון כוכבני",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "ביצה בצומת שבילים בשדות עיינות"
-    ],
-    "flowers": [
-      "דמסון כוכבני"
-    ],
-    "geocoded_locations": {
-      "ביצה בצומת שבילים בשדות עיינות": {
-        "latitude": 31.9253,
-        "longitude": 34.75
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_87_report_1_class.html"
-  },
-  {
-    "date": "20/04/2014",
-    "observer": "גדי פולק",
     "title": "נורית המלל",
     "description": [
       ""
@@ -136761,28 +126850,6 @@
     ],
     "flowers": [
       "נורית המלל"
-    ],
-    "geocoded_locations": {
-      "ביצה בצומת שבילים בשדות עיינות": {
-        "latitude": 31.9253,
-        "longitude": 34.75
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_87_report_1_class.html"
-  },
-  {
-    "date": "20/04/2014",
-    "observer": "גדי פולק",
-    "title": "אגמון ימי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "ביצה בצומת שבילים בשדות עיינות"
-    ],
-    "flowers": [
-      "אגמון ימי"
     ],
     "geocoded_locations": {
       "ביצה בצומת שבילים בשדות עיינות": {
@@ -136871,28 +126938,6 @@
     ],
     "flowers": [
       "בקית הביצות"
-    ],
-    "geocoded_locations": {
-      "שדות עיינות בריכת ורד צידוני": {
-        "latitude": 31.9231,
-        "longitude": 34.748
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_87_report_1_class.html"
-  },
-  {
-    "date": "20/04/2014",
-    "observer": "גדי פולק",
-    "title": "חומעה מסולסלת",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שדות עיינות בריכת ורד צידוני"
-    ],
-    "flowers": [
-      "חומעה מסולסלת"
     ],
     "geocoded_locations": {
       "שדות עיינות בריכת ורד צידוני": {
@@ -137223,50 +127268,6 @@
     ],
     "flowers": [
       "ארכובית הכתמים"
-    ],
-    "geocoded_locations": {
-      "שדות עיינות בריכת ורד צידוני": {
-        "latitude": 31.9231,
-        "longitude": 34.748
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_87_report_1_class.html"
-  },
-  {
-    "date": "20/04/2014",
-    "observer": "גדי פולק",
-    "title": "אגמון ימי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שדות עיינות בריכת ורד צידוני"
-    ],
-    "flowers": [
-      "אגמון ימי"
-    ],
-    "geocoded_locations": {
-      "שדות עיינות בריכת ורד צידוני": {
-        "latitude": 31.9231,
-        "longitude": 34.748
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_87_report_1_class.html"
-  },
-  {
-    "date": "20/04/2014",
-    "observer": "גדי פולק",
-    "title": "דמסון כוכבני",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שדות עיינות בריכת ורד צידוני"
-    ],
-    "flowers": [
-      "דמסון כוכבני"
     ],
     "geocoded_locations": {
       "שדות עיינות בריכת ורד צידוני": {
@@ -138035,23 +128036,6 @@
   },
   {
     "date": "15/04/2009",
-    "observer": "המטייל האנונימי",
-    "title": "אדמונית החורש",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "השביל השחור"
-    ],
-    "flowers": [
-      "אדמונית החורש"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_161_report_1_class.html"
-  },
-  {
-    "date": "15/04/2009",
     "observer": "נעם שגב",
     "title": "געדה כרתית",
     "description": [
@@ -138696,28 +128680,6 @@
   {
     "date": "05/02/2022",
     "observer": "Iddo_3270859",
-    "title": "רקפת מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "גבעת ברפיליה, חיים בר-לב, מודיעין מכבים רעות"
-    ],
-    "flowers": [
-      "רקפת מצויה"
-    ],
-    "geocoded_locations": {
-      "גבעת ברפיליה, חיים בר-לב, מודיעין מכבים רעות": {
-        "latitude": 31.9090429,
-        "longitude": 34.998517
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_32_report_1_class.html"
-  },
-  {
-    "date": "05/02/2022",
-    "observer": "Iddo_3270859",
     "title": "כלנית מצויה",
     "description": [
       ""
@@ -138996,28 +128958,6 @@
       "גבעת חומרה, פלמחים": {
         "latitude": 31.933839337649324,
         "longitude": 34.713906025439464
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_32_report_1_class.html"
-  },
-  {
-    "date": "02/02/2022",
-    "observer": "Iddo_3270859",
-    "title": "רקפת מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "גבעת הרקפות - טל שחר"
-    ],
-    "flowers": [
-      "רקפת מצויה"
-    ],
-    "geocoded_locations": {
-      "גבעת הרקפות - טל שחר": {
-        "latitude": 31.7905114,
-        "longitude": 34.8971959
       }
     },
     "coordinates": [],
@@ -139442,28 +129382,6 @@
     "source_file": "tiuli_scraped_reports/page_32_report_1_class.html"
   },
   {
-    "date": "22/01/2022",
-    "observer": "חנן - 4135815",
-    "title": "נרקיס מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "4RJ5+WC רמת השרון, ישראל"
-    ],
-    "flowers": [
-      "נרקיס מצוי"
-    ],
-    "geocoded_locations": {
-      "4RJ5+WC רמת השרון, ישראל": {
-        "latitude": 32.132322543308426,
-        "longitude": 34.80853973237349
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_32_report_1_class.html"
-  },
-  {
     "date": "06/03/2011",
     "observer": "lzuri",
     "title": "דבורנית דינסמור",
@@ -139772,40 +129690,6 @@
   {
     "date": "03/03/2011",
     "observer": "המטייל האנונימי",
-    "title": "תורמוס ההרים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל תבור"
-    ],
-    "flowers": [
-      "תורמוס ההרים"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_138_report_1_class.html"
-  },
-  {
-    "date": "03/03/2011",
-    "observer": "המטייל האנונימי",
-    "title": "תורמוס ההרים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "כביש 70, כ- 500 מטר ממחלף אליקים מערבה"
-    ],
-    "flowers": [
-      "תורמוס ההרים"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_138_report_1_class.html"
-  },
-  {
-    "date": "03/03/2011",
-    "observer": "המטייל האנונימי",
     "title": "אלקנת הצבעים",
     "description": [
       ""
@@ -139880,23 +129764,6 @@
     ],
     "locations": [
       "שמורת אירוס הארגמן בנתניה"
-    ],
-    "flowers": [
-      "אירוס הארגמן"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_138_report_1_class.html"
-  },
-  {
-    "date": "27/02/2011",
-    "observer": "המטייל האנונימי",
-    "title": "אירוס הארגמן",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שמורת האלונים ,קדימה"
     ],
     "flowers": [
       "אירוס הארגמן"
@@ -140095,40 +129962,6 @@
   {
     "date": "26/02/2011",
     "observer": "המטייל האנונימי",
-    "title": "צבעוני ההרים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער ראש העין"
-    ],
-    "flowers": [
-      "צבעוני ההרים"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_138_report_1_class.html"
-  },
-  {
-    "date": "26/02/2011",
-    "observer": "המטייל האנונימי",
-    "title": "סחלב פרפרני",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער ראש העין"
-    ],
-    "flowers": [
-      "סחלב פרפרני"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_138_report_1_class.html"
-  },
-  {
-    "date": "26/02/2011",
-    "observer": "המטייל האנונימי",
     "title": "דבורנית דינסמור",
     "description": [
       ""
@@ -140172,23 +130005,6 @@
     ],
     "flowers": [
       "צהרון מצוי"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_138_report_1_class.html"
-  },
-  {
-    "date": "26/02/2011",
-    "observer": "המטייל האנונימי",
-    "title": "דבורנית דינסמור",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חניון האגם ועין אלון"
-    ],
-    "flowers": [
-      "דבורנית דינסמור"
     ],
     "geocoded_locations": {},
     "coordinates": [],
@@ -140285,28 +130101,6 @@
   {
     "date": "07/02/2015",
     "observer": "איריס_בר",
-    "title": "זהבית השלוחות",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שויצריה הקטנה"
-    ],
-    "flowers": [
-      "זהבית השלוחות"
-    ],
-    "geocoded_locations": {
-      "שויצריה הקטנה": {
-        "latitude": 32.7596,
-        "longitude": 34.9969
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_81_report_1_class.html"
-  },
-  {
-    "date": "07/02/2015",
-    "observer": "איריס_בר",
     "title": "צבעוני ההרים",
     "description": [
       ""
@@ -140393,50 +130187,6 @@
     "source_file": "tiuli_scraped_reports/page_81_report_1_class.html"
   },
   {
-    "date": "07/02/2015",
-    "observer": "איריס_בר",
-    "title": "כרמלית נאה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שויצריה הקטנה"
-    ],
-    "flowers": [
-      "כרמלית נאה"
-    ],
-    "geocoded_locations": {
-      "שויצריה הקטנה": {
-        "latitude": 32.7503,
-        "longitude": 35.0079
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_81_report_1_class.html"
-  },
-  {
-    "date": "07/02/2015",
-    "observer": "איריס_בר",
-    "title": "רומולאה צידונית",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שויצריה הקטנה"
-    ],
-    "flowers": [
-      "רומולאה צידונית"
-    ],
-    "geocoded_locations": {
-      "שויצריה הקטנה": {
-        "latitude": 32.7503,
-        "longitude": 35.0079
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_81_report_1_class.html"
-  },
-  {
     "date": "06/02/2015",
     "observer": "יוחאי כורם",
     "title": "כלנית מצויה",
@@ -140453,28 +130203,6 @@
       "יער סעד": {
         "latitude": 31.4698,
         "longitude": 34.5301
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_81_report_1_class.html"
-  },
-  {
-    "date": "06/02/2015",
-    "observer": "יוחאי כורם",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שמורת בארי (מפעל הגופרית)"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "שמורת בארי (מפעל הגופרית)": {
-        "latitude": 31.4212,
-        "longitude": 34.4589
       }
     },
     "coordinates": [],
@@ -140629,28 +130357,6 @@
       "שמורת פורה": {
         "latitude": 31.4934,
         "longitude": 34.7738
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_81_report_1_class.html"
-  },
-  {
-    "date": "04/02/2015",
-    "observer": "עידו מגן",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער שוקדה"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "יער שוקדה": {
-        "latitude": 31.4256,
-        "longitude": 34.5111
       }
     },
     "coordinates": [],
@@ -140849,28 +130555,6 @@
       "ברכת צרטא162": {
         "latitude": 32.0171,
         "longitude": 34.9678
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_81_report_1_class.html"
-  },
-  {
-    "date": "03/02/2015",
-    "observer": "גדי פולק",
-    "title": "נורית המים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "ברכת צרטא"
-    ],
-    "flowers": [
-      "נורית המים"
-    ],
-    "geocoded_locations": {
-      "ברכת צרטא": {
-        "latitude": 32.0172,
-        "longitude": 34.9683
       }
     },
     "coordinates": [],
@@ -141405,28 +131089,6 @@
     "source_file": "tiuli_scraped_reports/page_57_report_1_class.html"
   },
   {
-    "date": "31/03/2018",
-    "observer": "עידו מגן",
-    "title": "כליל החורש",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "סאסא"
-    ],
-    "flowers": [
-      "כליל החורש"
-    ],
-    "geocoded_locations": {
-      "סאסא": {
-        "latitude": 33.02866,
-        "longitude": 35.39456900000005
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_57_report_1_class.html"
-  },
-  {
     "date": "27/03/2018",
     "observer": "אילאיי",
     "title": "אירוס ירוחם",
@@ -141869,28 +131531,6 @@
   {
     "date": "10/03/2018",
     "observer": "עידו מגן",
-    "title": "צהרון מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מלכישוע"
-    ],
-    "flowers": [
-      "צהרון מצוי"
-    ],
-    "geocoded_locations": {
-      "מלכישוע": {
-        "latitude": 32.438568,
-        "longitude": 35.412757000000056
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_57_report_1_class.html"
-  },
-  {
-    "date": "10/03/2018",
-    "observer": "עידו מגן",
     "title": "אירוס הגלבוע",
     "description": [
       ""
@@ -142120,28 +131760,6 @@
     ],
     "flowers": [
       "סחלב פרפרני"
-    ],
-    "geocoded_locations": {
-      "שמורת להב צפון": {
-        "latitude": 31.393743,
-        "longitude": 34.86661099999992
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_57_report_1_class.html"
-  },
-  {
-    "date": "03/03/2018",
-    "observer": "עידו מגן",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שמורת להב צפון"
-    ],
-    "flowers": [
-      "כלנית מצויה"
     ],
     "geocoded_locations": {
       "שמורת להב צפון": {
@@ -142553,28 +132171,6 @@
   {
     "date": "09/05/2013",
     "observer": "גדי פולק",
-    "title": "דו-פרק חופי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חוף בצת חולות מדרום למגרש החנייה"
-    ],
-    "flowers": [
-      "דו-פרק חופי"
-    ],
-    "geocoded_locations": {
-      "חוף בצת חולות מדרום למגרש החנייה": {
-        "latitude": 33.079,
-        "longitude": 35.1063
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_105_report_1_class.html"
-  },
-  {
-    "date": "09/05/2013",
-    "observer": "גדי פולק",
     "title": "גלדן סמרני",
     "description": [
       ""
@@ -142905,28 +132501,6 @@
   {
     "date": "09/05/2013",
     "observer": "גדי פולק",
-    "title": "עדעד כחול",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חוף ראש הנקרה - מצפון למעגל התנועה"
-    ],
-    "flowers": [
-      "עדעד כחול"
-    ],
-    "geocoded_locations": {
-      "חוף ראש הנקרה - מצפון למעגל התנועה": {
-        "latitude": 33.0358,
-        "longitude": 35.106
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_105_report_1_class.html"
-  },
-  {
-    "date": "09/05/2013",
-    "observer": "גדי פולק",
     "title": "חרחבינה מכחילה",
     "description": [
       ""
@@ -142980,94 +132554,6 @@
     ],
     "flowers": [
       "קורנית מקורקפת"
-    ],
-    "geocoded_locations": {
-      "חוף ראש הנקרה - מצפון למעגל התנועה": {
-        "latitude": 33.0358,
-        "longitude": 35.106
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_105_report_1_class.html"
-  },
-  {
-    "date": "09/05/2013",
-    "observer": "גדי פולק",
-    "title": "גלדן סמרני",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חוף ראש הנקרה - מצפון למעגל התנועה"
-    ],
-    "flowers": [
-      "גלדן סמרני"
-    ],
-    "geocoded_locations": {
-      "חוף ראש הנקרה - מצפון למעגל התנועה": {
-        "latitude": 33.0358,
-        "longitude": 35.106
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_105_report_1_class.html"
-  },
-  {
-    "date": "09/05/2013",
-    "observer": "גדי פולק",
-    "title": "אספסת הים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חוף ראש הנקרה - מצפון למעגל התנועה"
-    ],
-    "flowers": [
-      "אספסת הים"
-    ],
-    "geocoded_locations": {
-      "חוף ראש הנקרה - מצפון למעגל התנועה": {
-        "latitude": 33.0358,
-        "longitude": 35.106
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_105_report_1_class.html"
-  },
-  {
-    "date": "09/05/2013",
-    "observer": "גדי פולק",
-    "title": "מנתור החוף",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חוף ראש הנקרה - מצפון למעגל התנועה"
-    ],
-    "flowers": [
-      "מנתור החוף"
-    ],
-    "geocoded_locations": {
-      "חוף ראש הנקרה - מצפון למעגל התנועה": {
-        "latitude": 33.0358,
-        "longitude": 35.106
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_105_report_1_class.html"
-  },
-  {
-    "date": "09/05/2013",
-    "observer": "גדי פולק",
-    "title": "אספסת החוף",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חוף ראש הנקרה - מצפון למעגל התנועה"
-    ],
-    "flowers": [
-      "אספסת החוף"
     ],
     "geocoded_locations": {
       "חוף ראש הנקרה - מצפון למעגל התנועה": {
@@ -143169,116 +132655,6 @@
   {
     "date": "09/05/2013",
     "observer": "גדי פולק",
-    "title": "עדעד כחול",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חוף אכזיב צפון ליד החורשה"
-    ],
-    "flowers": [
-      "עדעד כחול"
-    ],
-    "geocoded_locations": {
-      "חוף אכזיב צפון ליד החורשה": {
-        "latitude": 33.0647,
-        "longitude": 35.1046
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_105_report_1_class.html"
-  },
-  {
-    "date": "09/05/2013",
-    "observer": "גדי פולק",
-    "title": "עכנאי שרוע",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חוף אכזיב צפון ליד החורשה"
-    ],
-    "flowers": [
-      "עכנאי שרוע"
-    ],
-    "geocoded_locations": {
-      "חוף אכזיב צפון ליד החורשה": {
-        "latitude": 33.0647,
-        "longitude": 35.1046
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_105_report_1_class.html"
-  },
-  {
-    "date": "09/05/2013",
-    "observer": "גדי פולק",
-    "title": "חבלבל החוף",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חוף אכזיב צפון ליד החורשה"
-    ],
-    "flowers": [
-      "חבלבל החוף"
-    ],
-    "geocoded_locations": {
-      "חוף אכזיב צפון ליד החורשה": {
-        "latitude": 33.0647,
-        "longitude": 35.1046
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_105_report_1_class.html"
-  },
-  {
-    "date": "09/05/2013",
-    "observer": "גדי פולק",
-    "title": "חלבלוב החוף",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חוף אכזיב צפון ליד החורשה"
-    ],
-    "flowers": [
-      "חלבלוב החוף"
-    ],
-    "geocoded_locations": {
-      "חוף אכזיב צפון ליד החורשה": {
-        "latitude": 33.0647,
-        "longitude": 35.1046
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_105_report_1_class.html"
-  },
-  {
-    "date": "09/05/2013",
-    "observer": "גדי פולק",
-    "title": "מנתור החוף",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חוף אכזיב צפון ליד החורשה"
-    ],
-    "flowers": [
-      "מנתור החוף"
-    ],
-    "geocoded_locations": {
-      "חוף אכזיב צפון ליד החורשה": {
-        "latitude": 33.0647,
-        "longitude": 35.1046
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_105_report_1_class.html"
-  },
-  {
-    "date": "09/05/2013",
-    "observer": "גדי פולק",
     "title": "מתנן שעיר",
     "description": [
       ""
@@ -143288,50 +132664,6 @@
     ],
     "flowers": [
       "מתנן שעיר"
-    ],
-    "geocoded_locations": {
-      "חוף אכזיב צפון ליד החורשה": {
-        "latitude": 33.0647,
-        "longitude": 35.1046
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_105_report_1_class.html"
-  },
-  {
-    "date": "09/05/2013",
-    "observer": "גדי פולק",
-    "title": "מדחול דוקרני",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חוף אכזיב צפון ליד החורשה"
-    ],
-    "flowers": [
-      "מדחול דוקרני"
-    ],
-    "geocoded_locations": {
-      "חוף אכזיב צפון ליד החורשה": {
-        "latitude": 33.0647,
-        "longitude": 35.1046
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_105_report_1_class.html"
-  },
-  {
-    "date": "09/05/2013",
-    "observer": "גדי פולק",
-    "title": "קריתמון ימי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חוף אכזיב צפון ליד החורשה"
-    ],
-    "flowers": [
-      "קריתמון ימי"
     ],
     "geocoded_locations": {
       "חוף אכזיב צפון ליד החורשה": {
@@ -143477,28 +132809,6 @@
   {
     "date": "17/02/2017",
     "observer": "עידו מגן",
-    "title": "שקד מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "כביש 90 צפון"
-    ],
-    "flowers": [
-      "שקד מצוי"
-    ],
-    "geocoded_locations": {
-      "כביש 90 צפון": {
-        "latitude": 33.0471,
-        "longitude": 35.573
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_66_report_1_class.html"
-  },
-  {
-    "date": "17/02/2017",
-    "observer": "עידו מגן",
     "title": "עירית גדולה",
     "description": [
       ""
@@ -143557,28 +132867,6 @@
       "רמות מנשה": {
         "latitude": 32.5807,
         "longitude": 35.0409
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_66_report_1_class.html"
-  },
-  {
-    "date": "17/02/2017",
-    "observer": "אלחי47",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "רמות מנשה"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "רמות מנשה": {
-        "latitude": 32.5801,
-        "longitude": 35.0374
       }
     },
     "coordinates": [],
@@ -143675,28 +132963,6 @@
   {
     "date": "11/02/2017",
     "observer": "המטייל האנונימי",
-    "title": "יקינתון מזרחי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "גליל תחתון-חורבת עמודים"
-    ],
-    "flowers": [
-      "יקינתון מזרחי"
-    ],
-    "geocoded_locations": {
-      "גליל תחתון-חורבת עמודים": {
-        "latitude": 32.8158,
-        "longitude": 35.4098
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_66_report_1_class.html"
-  },
-  {
-    "date": "11/02/2017",
-    "observer": "המטייל האנונימי",
     "title": "כלנית מצויה",
     "description": [
       ""
@@ -143777,28 +133043,6 @@
       "חורבת נכס ליד ישפרו סנטר מודיעין": {
         "latitude": 31.8886,
         "longitude": 34.9561
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_66_report_1_class.html"
-  },
-  {
-    "date": "11/02/2017",
-    "observer": "עידו מגן",
-    "title": "שקד מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מיני ישראל"
-    ],
-    "flowers": [
-      "שקד מצוי"
-    ],
-    "geocoded_locations": {
-      "מיני ישראל": {
-        "latitude": 31.8382,
-        "longitude": 34.9733
       }
     },
     "coordinates": [],
@@ -144049,50 +133293,6 @@
   {
     "date": "10/02/2017",
     "observer": "עידו מגן",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "בתרונות רוחמה"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "בתרונות רוחמה": {
-        "latitude": 31.4826,
-        "longitude": 34.6797
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_66_report_1_class.html"
-  },
-  {
-    "date": "10/02/2017",
-    "observer": "עידו מגן",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      " קיבוץ אור הנר"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      " קיבוץ אור הנר": {
-        "latitude": 31.5532,
-        "longitude": 34.6141
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_66_report_1_class.html"
-  },
-  {
-    "date": "10/02/2017",
-    "observer": "עידו מגן",
     "title": "שקד מצוי",
     "description": [
       ""
@@ -144107,28 +133307,6 @@
       " קיבוץ אור הנר": {
         "latitude": 31.5532,
         "longitude": 34.6141
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_66_report_1_class.html"
-  },
-  {
-    "date": "10/02/2017",
-    "observer": "עידו מגן",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער שוקדה"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "יער שוקדה": {
-        "latitude": 31.427,
-        "longitude": 34.5179
       }
     },
     "coordinates": [],
@@ -145180,72 +134358,6 @@
   {
     "date": "07/03/2013",
     "observer": "גדי פולק",
-    "title": "פגוניה ערבית",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "בדרך לעמודי עמרם"
-    ],
-    "flowers": [
-      "פגוניה ערבית"
-    ],
-    "geocoded_locations": {
-      "בדרך לעמודי עמרם": {
-        "latitude": 29.632,
-        "longitude": 34.9468
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_109_report_1_class.html"
-  },
-  {
-    "date": "07/03/2013",
-    "observer": "גדי פולק",
-    "title": "טוריים מדבריים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל שלמה- ואדיון ליד חניון"
-    ],
-    "flowers": [
-      "טוריים מדבריים"
-    ],
-    "geocoded_locations": {
-      "נחל שלמה- ואדיון ליד חניון": {
-        "latitude": 29.529,
-        "longitude": 34.9091
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_109_report_1_class.html"
-  },
-  {
-    "date": "07/03/2013",
-    "observer": "גדי פולק",
-    "title": "פגוניה ערבית",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל שלמה- ואדיון ליד חניון"
-    ],
-    "flowers": [
-      "פגוניה ערבית"
-    ],
-    "geocoded_locations": {
-      "נחל שלמה- ואדיון ליד חניון": {
-        "latitude": 29.529,
-        "longitude": 34.9091
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_109_report_1_class.html"
-  },
-  {
-    "date": "07/03/2013",
-    "observer": "גדי פולק",
     "title": "פרעושית גלונית",
     "description": [
       ""
@@ -145884,28 +134996,6 @@
   {
     "date": "26/03/2017",
     "observer": "אלחי47",
-    "title": "סיפן התבואה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "גליל תחתון הר טורעו"
-    ],
-    "flowers": [
-      "סיפן התבואה"
-    ],
-    "geocoded_locations": {
-      "גליל תחתון הר טורעו": {
-        "latitude": 32.7881,
-        "longitude": 35.3834
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_62_report_1_class.html"
-  },
-  {
-    "date": "26/03/2017",
-    "observer": "אלחי47",
     "title": "אירוס הגלבוע",
     "description": [
       ""
@@ -146103,28 +135193,6 @@
   },
   {
     "date": "25/03/2017",
-    "observer": "יוחאי כורם",
-    "title": "בן-חצב יקינתוני",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שמורת יקום"
-    ],
-    "flowers": [
-      "בן-חצב יקינתוני"
-    ],
-    "geocoded_locations": {
-      "שמורת יקום": {
-        "latitude": 32.2556,
-        "longitude": 34.8378
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_62_report_1_class.html"
-  },
-  {
-    "date": "25/03/2017",
     "observer": "המטייל האנונימי",
     "title": "לוטם מרווני",
     "description": [
@@ -146140,28 +135208,6 @@
       "רחובות": {
         "latitude": 31.8736,
         "longitude": 34.8094
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_62_report_1_class.html"
-  },
-  {
-    "date": "25/03/2017",
-    "observer": "עידו מגן",
-    "title": "בן-חצב יקינתוני",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חניון גרשון וחנה הדס בפארק עצמאות ארה"
-    ],
-    "flowers": [
-      "בן-חצב יקינתוני"
-    ],
-    "geocoded_locations": {
-      "חניון גרשון וחנה הדס בפארק עצמאות ארה": {
-        "latitude": 203213.0,
-        "longitude": 628140.0
       }
     },
     "coordinates": [],
@@ -146311,28 +135357,6 @@
     ],
     "flowers": [
       "תורמוס ההרים"
-    ],
-    "geocoded_locations": {
-      "תל שוכה מעל עמק האלה": {
-        "latitude": 31.6835,
-        "longitude": 34.9654
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_62_report_1_class.html"
-  },
-  {
-    "date": "25/03/2017",
-    "observer": "עידו מגן",
-    "title": "רקפת מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "תל שוכה מעל עמק האלה"
-    ],
-    "flowers": [
-      "רקפת מצויה"
     ],
     "geocoded_locations": {
       "תל שוכה מעל עמק האלה": {
@@ -146720,28 +135744,6 @@
   {
     "date": "21/02/2013",
     "observer": "גדי פולק",
-    "title": "ציפורני-חתול מצויות",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "באר שבע ליד הגן הזואולוגי; קירטון"
-    ],
-    "flowers": [
-      "ציפורני-חתול מצויות"
-    ],
-    "geocoded_locations": {
-      "באר שבע ליד הגן הזואולוגי; קירטון": {
-        "latitude": 31.2551,
-        "longitude": 34.7483
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_114_report_1_class.html"
-  },
-  {
-    "date": "21/02/2013",
-    "observer": "גדי פולק",
     "title": "כלנית מצויה",
     "description": [
       ""
@@ -146905,50 +135907,6 @@
     ],
     "flowers": [
       "ערטנית השדות"
-    ],
-    "geocoded_locations": {
-      "נחל עשן באר שבע": {
-        "latitude": 31.2713,
-        "longitude": 34.7492
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_114_report_1_class.html"
-  },
-  {
-    "date": "21/02/2013",
-    "observer": "גדי פולק",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל עשן באר שבע"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "נחל עשן באר שבע": {
-        "latitude": 31.2713,
-        "longitude": 34.7492
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_114_report_1_class.html"
-  },
-  {
-    "date": "21/02/2013",
-    "observer": "גדי פולק",
-    "title": "זמזומית איג",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל עשן באר שבע"
-    ],
-    "flowers": [
-      "זמזומית איג"
     ],
     "geocoded_locations": {
       "נחל עשן באר שבע": {
@@ -147175,23 +136133,6 @@
     ],
     "locations": [
       "אור הנר"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_114_report_1_class.html"
-  },
-  {
-    "date": "13/02/2013",
-    "observer": "עידו מגן",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער שוקדה"
     ],
     "flowers": [
       "כלנית מצויה"
@@ -147493,50 +136434,6 @@
   {
     "date": "25/01/2025",
     "observer": "Iddo_3270859",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חבצלת השרון, חדרה"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "חבצלת השרון, חדרה": {
-        "latitude": 32.423015909286036,
-        "longitude": 34.88356065138842
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_1_report_1_class.html"
-  },
-  {
-    "date": "25/01/2025",
-    "observer": "Iddo_3270859",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "עין הים, חדרה"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "עין הים, חדרה": {
-        "latitude": 32.427675,
-        "longitude": 34.883055
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_1_report_1_class.html"
-  },
-  {
-    "date": "25/01/2025",
-    "observer": "Iddo_3270859",
     "title": "סחלב השקיק",
     "description": [
       ""
@@ -147639,28 +136536,6 @@
       "גשרון אוהד": {
         "latitude": 32.22442852142055,
         "longitude": 34.84596351975788
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_1_report_1_class.html"
-  },
-  {
-    "date": "18/01/2025",
-    "observer": "Iddo_3270859",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "גבעת אלון התבור, Bne Dror"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "גבעת אלון התבור, Bne Dror": {
-        "latitude": 32.2580256,
-        "longitude": 34.8973518
       }
     },
     "coordinates": [],
@@ -147823,28 +136698,6 @@
   {
     "date": "10/01/2025",
     "observer": "Iddo_3270859",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "ארזי הלבנון, חדרה"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "ארזי הלבנון, חדרה": {
-        "latitude": 32.424376916038874,
-        "longitude": 34.88179021401108
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_1_report_1_class.html"
-  },
-  {
-    "date": "10/01/2025",
-    "observer": "Iddo_3270859",
     "title": "רקפת מצויה",
     "description": [
       ""
@@ -147867,28 +136720,6 @@
   {
     "date": "10/01/2025",
     "observer": "Iddo_3270859",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "תיכון כרמים בנימינה, בנימינה גבעת עדה"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "תיכון כרמים בנימינה, בנימינה גבעת עדה": {
-        "latitude": 32.5476860247254,
-        "longitude": 34.95476678306438
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_1_report_1_class.html"
-  },
-  {
-    "date": "10/01/2025",
-    "observer": "Iddo_3270859",
     "title": "אירוס ארץ-ישראלי",
     "description": [
       ""
@@ -147898,28 +136729,6 @@
     ],
     "flowers": [
       "אירוס ארץ-ישראלי"
-    ],
-    "geocoded_locations": {
-      "חורבת המלח, התדהר, אור עקיבא": {
-        "latitude": 32.5237873,
-        "longitude": 34.92060050000001
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_1_report_1_class.html"
-  },
-  {
-    "date": "10/01/2025",
-    "observer": "Iddo_3270859",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חורבת המלח, התדהר, אור עקיבא"
-    ],
-    "flowers": [
-      "כלנית מצויה"
     ],
     "geocoded_locations": {
       "חורבת המלח, התדהר, אור עקיבא": {
@@ -147969,28 +136778,6 @@
       "שמורת שער פולג": {
         "latitude": 32.256896,
         "longitude": 34.84253229999999
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_1_report_1_class.html"
-  },
-  {
-    "date": "03/01/2025",
-    "observer": "Iddo_3270859",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שמורת טבע תל יצחק, מועצה אזורית חוף השרון"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "שמורת טבע תל יצחק, מועצה אזורית חוף השרון": {
-        "latitude": 32.25038249999999,
-        "longitude": 34.8610095
       }
     },
     "coordinates": [],
@@ -148129,28 +136916,6 @@
     "source_file": "tiuli_scraped_reports/page_1_report_1_class.html"
   },
   {
-    "date": "21/12/2024",
-    "observer": "Iddo_3270859",
-    "title": "רקפת מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער הרקפות, דרך הפרחים, כוכב יאיר צור יגאל"
-    ],
-    "flowers": [
-      "רקפת מצויה"
-    ],
-    "geocoded_locations": {
-      "יער הרקפות, דרך הפרחים, כוכב יאיר צור יגאל": {
-        "latitude": 32.2214999,
-        "longitude": 34.9998682
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_1_report_1_class.html"
-  },
-  {
     "date": "15/12/2024",
     "observer": "Iddo_3270859",
     "title": "נרקיס מצוי",
@@ -148175,50 +136940,6 @@
   {
     "date": "15/12/2024",
     "observer": "Iddo_3270859",
-    "title": "נרקיס מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל כרמילה"
-    ],
-    "flowers": [
-      "נרקיס מצוי"
-    ],
-    "geocoded_locations": {
-      "נחל כרמילה": {
-        "latitude": 31.785363,
-        "longitude": 35.027181
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_1_report_1_class.html"
-  },
-  {
-    "date": "15/12/2024",
-    "observer": "Iddo_3270859",
-    "title": "נרקיס מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "דיר אל מוחרקה מנזר הכרמליתים, דאלית אל-כרמל"
-    ],
-    "flowers": [
-      "נרקיס מצוי"
-    ],
-    "geocoded_locations": {
-      "דיר אל מוחרקה מנזר הכרמליתים, דאלית אל-כרמל": {
-        "latitude": 32.67268749999999,
-        "longitude": 35.08831250000001
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_1_report_1_class.html"
-  },
-  {
-    "date": "15/12/2024",
-    "observer": "Iddo_3270859",
     "title": "רקפת מצויה",
     "description": [
       ""
@@ -148228,28 +136949,6 @@
     ],
     "flowers": [
       "רקפת מצויה"
-    ],
-    "geocoded_locations": {
-      "מדרגות בירידה לכסלון, שביל ישראל": {
-        "latitude": 31.7807349,
-        "longitude": 35.0356414
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_1_report_1_class.html"
-  },
-  {
-    "date": "15/12/2024",
-    "observer": "Iddo_3270859",
-    "title": "נרקיס מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מדרגות בירידה לכסלון, שביל ישראל"
-    ],
-    "flowers": [
-      "נרקיס מצוי"
     ],
     "geocoded_locations": {
       "מדרגות בירידה לכסלון, שביל ישראל": {
@@ -148820,23 +137519,6 @@
   {
     "date": "15/05/2009",
     "observer": "המטייל האנונימי",
-    "title": "שושן צחור",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הר פקיעין"
-    ],
-    "flowers": [
-      "שושן צחור"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_160_report_1_class.html"
-  },
-  {
-    "date": "15/05/2009",
-    "observer": "המטייל האנונימי",
     "title": "לוטם שעיר",
     "description": [
       ""
@@ -149092,23 +137774,6 @@
   {
     "date": "02/05/2009",
     "observer": "המטייל האנונימי",
-    "title": "אירוס ארם-נהריים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "כביש הכניסה לאליעד"
-    ],
-    "flowers": [
-      "אירוס ארם-נהריים"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_160_report_1_class.html"
-  },
-  {
-    "date": "02/05/2009",
-    "observer": "המטייל האנונימי",
     "title": "לוע-ארי גדול",
     "description": [
       ""
@@ -149321,28 +137986,6 @@
   {
     "date": "13/02/2016",
     "observer": "עידו מגן",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק יער חדרה"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "פארק יער חדרה": {
-        "latitude": 32.4167,
-        "longitude": 34.895
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_72_report_1_class.html"
-  },
-  {
-    "date": "13/02/2016",
-    "observer": "עידו מגן",
     "title": "רקפת מצויה",
     "description": [
       ""
@@ -149401,28 +138044,6 @@
       "צפון הנגב": {
         "latitude": 31.364,
         "longitude": 34.4431
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_72_report_1_class.html"
-  },
-  {
-    "date": "13/02/2016",
-    "observer": "אלחי47",
-    "title": "דבורנית דינסמור",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "צפון הנגב"
-    ],
-    "flowers": [
-      "דבורנית דינסמור"
-    ],
-    "geocoded_locations": {
-      "צפון הנגב": {
-        "latitude": 31.3993,
-        "longitude": 34.4347
       }
     },
     "coordinates": [],
@@ -149737,28 +138358,6 @@
     "source_file": "tiuli_scraped_reports/page_72_report_1_class.html"
   },
   {
-    "date": "29/01/2016",
-    "observer": "עידו מגן",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "בתרונות רוחמה"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "בתרונות רוחמה": {
-        "latitude": 31.4913,
-        "longitude": 34.7153
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_72_report_1_class.html"
-  },
-  {
     "date": "27/01/2016",
     "observer": "עידו מגן",
     "title": "רקפת מצויה",
@@ -149863,28 +138462,6 @@
       "ראש נחל חלילים": {
         "latitude": 31.8055,
         "longitude": 35.1546
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_72_report_1_class.html"
-  },
-  {
-    "date": "16/01/2016",
-    "observer": "עידו מגן",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חרבת חנות"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "חרבת חנות": {
-        "latitude": 31.7127,
-        "longitude": 35.0466
       }
     },
     "coordinates": [],
@@ -150112,28 +138689,6 @@
   },
   {
     "date": "09/01/2016",
-    "observer": "עידו מגן",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק יער שוהם"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "פארק יער שוהם": {
-        "latitude": 32.0036,
-        "longitude": 34.9628
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_72_report_1_class.html"
-  },
-  {
-    "date": "09/01/2016",
     "observer": "המטייל האנונימי",
     "title": "אירוס ארץ-ישראלי",
     "description": [
@@ -150347,28 +138902,6 @@
       "פארק איילון קנדה, דוידזון, ראשון לציון": {
         "latitude": 31.83871715495204,
         "longitude": 34.999382727917265
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_2_report_1_class.html"
-  },
-  {
-    "date": "30/11/2024",
-    "observer": "Iddo_3270859",
-    "title": "סתוונית היורה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער הקדושים"
-    ],
-    "flowers": [
-      "סתוונית היורה"
-    ],
-    "geocoded_locations": {
-      "יער הקדושים": {
-        "latitude": 31.780977004582166,
-        "longitude": 35.05375378851111
       }
     },
     "coordinates": [],
@@ -150793,28 +139326,6 @@
     "source_file": "tiuli_scraped_reports/page_2_report_1_class.html"
   },
   {
-    "date": "14/09/2024",
-    "observer": "Iddo_3270859",
-    "title": "חצב מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "גבעות מרר"
-    ],
-    "flowers": [
-      "חצב מצוי"
-    ],
-    "geocoded_locations": {
-      "גבעות מרר": {
-        "latitude": 31.84040459999999,
-        "longitude": 34.78571389999999
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_2_report_1_class.html"
-  },
-  {
     "date": "03/09/2024",
     "observer": "Iddo_3270859",
     "title": "חצב מצוי",
@@ -151103,28 +139614,6 @@
   {
     "date": "23/04/2024",
     "observer": "Iddo_3270859",
-    "title": "דבורנית גדולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "גבעת יערים"
-    ],
-    "flowers": [
-      "דבורנית גדולה"
-    ],
-    "geocoded_locations": {
-      "גבעת יערים": {
-        "latitude": 31.786089,
-        "longitude": 35.09277
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_2_report_1_class.html"
-  },
-  {
-    "date": "23/04/2024",
-    "observer": "Iddo_3270859",
     "title": "אירוס ארם-נהריים",
     "description": [
       ""
@@ -151139,28 +139628,6 @@
       "פארק ארזים, ירושלים": {
         "latitude": 31.8011846,
         "longitude": 35.1714792
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_2_report_1_class.html"
-  },
-  {
-    "date": "23/04/2024",
-    "observer": "Iddo_3270859",
-    "title": "אירוס ארם-נהריים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק איילון קנדה, דוידזון, ראשון לציון"
-    ],
-    "flowers": [
-      "אירוס ארם-נהריים"
-    ],
-    "geocoded_locations": {
-      "פארק איילון קנדה, דוידזון, ראשון לציון": {
-        "latitude": 31.837287559650466,
-        "longitude": 34.99299130898952
       }
     },
     "coordinates": [],
@@ -151183,28 +139650,6 @@
       "נחל כזיב": {
         "latitude": 33.01503864666511,
         "longitude": 35.39165391953012
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_2_report_1_class.html"
-  },
-  {
-    "date": "21/04/2024",
-    "observer": "Iddo_3270859",
-    "title": "סחלבן החורש",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שביל האדמוניות, דרך לחניון הר כפיר"
-    ],
-    "flowers": [
-      "סחלבן החורש"
-    ],
-    "geocoded_locations": {
-      "שביל האדמוניות, דרך לחניון הר כפיר": {
-        "latitude": 32.9611062,
-        "longitude": 35.4197036
       }
     },
     "coordinates": [],
@@ -154458,28 +142903,6 @@
   {
     "date": "04/03/2020",
     "observer": "עידו מגן",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מעגן מיכאל"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "מעגן מיכאל": {
-        "latitude": 32.55871,
-        "longitude": 34.917816
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_50_report_1_class.html"
-  },
-  {
-    "date": "04/03/2020",
-    "observer": "עידו מגן",
     "title": "תורמוס ארץ-ישראלי",
     "description": [
       ""
@@ -154758,28 +143181,6 @@
       "גבעת חומרה, פלמחים": {
         "latitude": 31.9322004,
         "longitude": 34.7082412
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_50_report_1_class.html"
-  },
-  {
-    "date": "02/03/2020",
-    "observer": "עידו מגן",
-    "title": "נורית אסיה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "גבעות הכורכר, נס ציונה"
-    ],
-    "flowers": [
-      "נורית אסיה"
-    ],
-    "geocoded_locations": {
-      "גבעות הכורכר, נס ציונה": {
-        "latitude": 31.9332388,
-        "longitude": 34.7837036
       }
     },
     "coordinates": [],
@@ -155611,28 +144012,6 @@
     ],
     "flowers": [
       "סוף מצוי"
-    ],
-    "geocoded_locations": {
-      "\"ברכת בטיח דרומית ע\"י כביש 65\"": {
-        "latitude": 32.4618,
-        "longitude": 34.937
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_85_report_1_class.html"
-  },
-  {
-    "date": "22/05/2014",
-    "observer": "גדי פולק",
-    "title": "עבדקן החוף",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "\"ברכת בטיח דרומית ע\"י כביש 65\""
-    ],
-    "flowers": [
-      "עבדקן החוף"
     ],
     "geocoded_locations": {
       "\"ברכת בטיח דרומית ע\"י כביש 65\"": {
@@ -156587,28 +144966,6 @@
   {
     "date": "09/05/2013",
     "observer": "גדי פולק",
-    "title": "גלדן סמרני",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חוף שבי ציון דרום"
-    ],
-    "flowers": [
-      "גלדן סמרני"
-    ],
-    "geocoded_locations": {
-      "חוף שבי ציון דרום": {
-        "latitude": 33.0647,
-        "longitude": 35.1046
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_106_report_1_class.html"
-  },
-  {
-    "date": "09/05/2013",
-    "observer": "גדי פולק",
     "title": "מדחול דוקרני",
     "description": [
       ""
@@ -156653,28 +145010,6 @@
   {
     "date": "09/05/2013",
     "observer": "גדי פולק",
-    "title": "אספסת החוף",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חוף שבי ציון דרום"
-    ],
-    "flowers": [
-      "אספסת החוף"
-    ],
-    "geocoded_locations": {
-      "חוף שבי ציון דרום": {
-        "latitude": 33.0647,
-        "longitude": 35.1046
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_106_report_1_class.html"
-  },
-  {
-    "date": "09/05/2013",
-    "observer": "גדי פולק",
     "title": "מלוח קיפח",
     "description": [
       ""
@@ -156684,28 +145019,6 @@
     ],
     "flowers": [
       "מלוח קיפח"
-    ],
-    "geocoded_locations": {
-      "חוף שבי ציון דרום": {
-        "latitude": 33.0647,
-        "longitude": 35.1046
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_106_report_1_class.html"
-  },
-  {
-    "date": "09/05/2013",
-    "observer": "גדי פולק",
-    "title": "לבנונית ימית",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חוף שבי ציון דרום"
-    ],
-    "flowers": [
-      "לבנונית ימית"
     ],
     "geocoded_locations": {
       "חוף שבי ציון דרום": {
@@ -158660,23 +146973,6 @@
   {
     "date": "25/03/2007",
     "observer": "המטייל האנונימי",
-    "title": "דרדר כחול",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "גבעת גד מערבה לאמציה"
-    ],
-    "flowers": [
-      "דרדר כחול"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_183_report_1_class.html"
-  },
-  {
-    "date": "25/03/2007",
-    "observer": "המטייל האנונימי",
     "title": "דבורנית שחומה",
     "description": [
       ""
@@ -158873,23 +147169,6 @@
     ],
     "flowers": [
       "קוציץ סורי"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_183_report_1_class.html"
-  },
-  {
-    "date": "23/03/2007",
-    "observer": "המטייל האנונימי",
-    "title": "צהרון מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל חלילים - מבשרת ציון"
-    ],
-    "flowers": [
-      "צהרון מצוי"
     ],
     "geocoded_locations": {},
     "coordinates": [],
@@ -159911,63 +148190,12 @@
   {
     "date": "14/10/2007",
     "observer": "המטייל האנונימי",
-    "title": "חלמונית גדולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "ירוחם"
-    ],
-    "flowers": [
-      "חלמונית גדולה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_179_report_1_class.html"
-  },
-  {
-    "date": "14/10/2007",
-    "observer": "המטייל האנונימי",
-    "title": "חלמונית גדולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הר חוזק - רכס בשנית"
-    ],
-    "flowers": [
-      "חלמונית גדולה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_179_report_1_class.html"
-  },
-  {
-    "date": "14/10/2007",
-    "observer": "המטייל האנונימי",
     "title": "סתוונית התשבץ",
     "description": [
       ""
     ],
     "locations": [
       "עין זיוון"
-    ],
-    "flowers": [
-      "סתוונית התשבץ"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_179_report_1_class.html"
-  },
-  {
-    "date": "14/10/2007",
-    "observer": "המטייל האנונימי",
-    "title": "סתוונית התשבץ",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הר חוזק"
     ],
     "flowers": [
       "סתוונית התשבץ"
@@ -160240,23 +148468,6 @@
     ],
     "locations": [
       "רכס שועפת,בין רמת שלמה לשועפת"
-    ],
-    "flowers": [
-      "חצב מצוי"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_179_report_1_class.html"
-  },
-  {
-    "date": "26/08/2007",
-    "observer": "המטייל האנונימי",
-    "title": "חצב מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "כביש הכניסה לגבעת ברנר מצפון."
     ],
     "flowers": [
       "חצב מצוי"
@@ -160722,28 +148933,6 @@
   {
     "date": "23/03/2024",
     "observer": "Iddo_3270859",
-    "title": "נורית אסיה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק רמות מנשה"
-    ],
-    "flowers": [
-      "נורית אסיה"
-    ],
-    "geocoded_locations": {
-      "פארק רמות מנשה": {
-        "latitude": 32.5980363,
-        "longitude": 35.1227522
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_4_report_1_class.html"
-  },
-  {
-    "date": "23/03/2024",
-    "observer": "Iddo_3270859",
     "title": "כליל החורש",
     "description": [
       ""
@@ -160897,50 +149086,6 @@
   },
   {
     "date": "22/03/2024",
-    "observer": "Iddo_3270859",
-    "title": "כליל החורש",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער לח\"י"
-    ],
-    "flowers": [
-      "כליל החורש"
-    ],
-    "geocoded_locations": {
-      "יער לח\"י": {
-        "latitude": 31.8667551,
-        "longitude": 34.9541077
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_4_report_1_class.html"
-  },
-  {
-    "date": "22/03/2024",
-    "observer": "Iddo_3270859",
-    "title": "כליל החורש",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער המגינים"
-    ],
-    "flowers": [
-      "כליל החורש"
-    ],
-    "geocoded_locations": {
-      "יער המגינים": {
-        "latitude": 31.8417906,
-        "longitude": 34.9269259
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_4_report_1_class.html"
-  },
-  {
-    "date": "22/03/2024",
     "observer": "Yossi_Dadi",
     "title": "סחלב פרפרני",
     "description": [
@@ -160978,28 +149123,6 @@
       "לטרון, לטרון": {
         "latitude": 31.836891,
         "longitude": 34.977195
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_4_report_1_class.html"
-  },
-  {
-    "date": "20/03/2024",
-    "observer": "Iddo_3270859",
-    "title": "כליל החורש",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שער הגיא החאן (באב אל וואד), חאן, שער הגיא, אשתאול"
-    ],
-    "flowers": [
-      "כליל החורש"
-    ],
-    "geocoded_locations": {
-      "שער הגיא החאן (באב אל וואד), חאן, שער הגיא, אשתאול": {
-        "latitude": 31.8148214,
-        "longitude": 35.0231697
       }
     },
     "coordinates": [],
@@ -161110,28 +149233,6 @@
       "רמת הנדיב, זכרון יעקב": {
         "latitude": 32.5524324,
         "longitude": 34.9453
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_4_report_1_class.html"
-  },
-  {
-    "date": "16/03/2024",
-    "observer": "סגלית ליהי_3323524",
-    "title": "סחלב שלוש השיניים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "רמת הנדיב"
-    ],
-    "flowers": [
-      "סחלב שלוש השיניים"
-    ],
-    "geocoded_locations": {
-      "רמת הנדיב": {
-        "latitude": 32.551466972670674,
-        "longitude": 34.94210514702139
       }
     },
     "coordinates": [],
@@ -162143,23 +150244,6 @@
     "source_file": "tiuli_scraped_reports/page_181_report_1_class.html"
   },
   {
-    "date": "18/04/2007",
-    "observer": "המטייל האנונימי",
-    "title": "סחלבן החורש",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הר הילל - שמורת הר מירון"
-    ],
-    "flowers": [
-      "סחלבן החורש"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_181_report_1_class.html"
-  },
-  {
     "date": "17/04/2007",
     "observer": "המטייל האנונימי",
     "title": "ורוניקה קרחת",
@@ -162553,40 +150637,6 @@
   {
     "date": "28/01/2007",
     "observer": "המטייל האנונימי",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "קיבוץ בארי"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_189_report_1_class.html"
-  },
-  {
-    "date": "28/01/2007",
-    "observer": "המטייל האנונימי",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שמורת בני ציון"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_189_report_1_class.html"
-  },
-  {
-    "date": "28/01/2007",
-    "observer": "המטייל האנונימי",
     "title": "אירוס ארץ-ישראלי",
     "description": [
       ""
@@ -162630,23 +150680,6 @@
     ],
     "flowers": [
       "ציפורן נקוד"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_189_report_1_class.html"
-  },
-  {
-    "date": "28/01/2007",
-    "observer": "המטייל האנונימי",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הר נוף"
-    ],
-    "flowers": [
-      "כלנית מצויה"
     ],
     "geocoded_locations": {},
     "coordinates": [],
@@ -162723,23 +150756,6 @@
   {
     "date": "27/01/2007",
     "observer": "המטייל האנונימי",
-    "title": "אירוס ארץ-ישראלי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "בקעת אלון - על שביל ישראל, למרגלות הר שוקף"
-    ],
-    "flowers": [
-      "אירוס ארץ-ישראלי"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_189_report_1_class.html"
-  },
-  {
-    "date": "27/01/2007",
-    "observer": "המטייל האנונימי",
     "title": "אירוס הארגמן",
     "description": [
       ""
@@ -162749,23 +150765,6 @@
     ],
     "flowers": [
       "אירוס הארגמן"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_189_report_1_class.html"
-  },
-  {
-    "date": "27/01/2007",
-    "observer": "המטייל האנונימי",
-    "title": "אירוס ארץ-ישראלי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הר אדיר (אזור התצפית לכיוון לבנון )"
-    ],
-    "flowers": [
-      "אירוס ארץ-ישראלי"
     ],
     "geocoded_locations": {},
     "coordinates": [],
@@ -163105,28 +151104,6 @@
     "source_file": "tiuli_scraped_reports/page_51_report_1_class.html"
   },
   {
-    "date": "18/02/2020",
-    "observer": "עידו מגן",
-    "title": "שקד מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "רחוב הרצל, ראשון לציון"
-    ],
-    "flowers": [
-      "שקד מצוי"
-    ],
-    "geocoded_locations": {
-      "רחוב הרצל, ראשון לציון": {
-        "latitude": 31.953076517533418,
-        "longitude": 34.802215538623045
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_51_report_1_class.html"
-  },
-  {
     "date": "17/02/2020",
     "observer": "מטייל_4104588",
     "title": "אירוס הארגמן",
@@ -163215,28 +151192,6 @@
     "source_file": "tiuli_scraped_reports/page_51_report_1_class.html"
   },
   {
-    "date": "15/02/2020",
-    "observer": "עידו מגן",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "תל בית שמש, בית שמש"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "תל בית שמש, בית שמש": {
-        "latitude": 31.75030299999999,
-        "longitude": 34.975495
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_51_report_1_class.html"
-  },
-  {
     "date": "14/02/2020",
     "observer": "Iddo_3270859",
     "title": "שקד מצוי",
@@ -163297,94 +151252,6 @@
       "יער הקדושים": {
         "latitude": 31.780806,
         "longitude": 35.06132599999999
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_51_report_1_class.html"
-  },
-  {
-    "date": "14/02/2020",
-    "observer": "Iddo_3270859",
-    "title": "רקפת מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חניון הרב גרשון וחנה הדס"
-    ],
-    "flowers": [
-      "רקפת מצויה"
-    ],
-    "geocoded_locations": {
-      "חניון הרב גרשון וחנה הדס": {
-        "latitude": 31.7474723,
-        "longitude": 35.03383
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_51_report_1_class.html"
-  },
-  {
-    "date": "14/02/2020",
-    "observer": "Iddo_3270859",
-    "title": "עירית גדולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חניון הרב גרשון וחנה הדס"
-    ],
-    "flowers": [
-      "עירית גדולה"
-    ],
-    "geocoded_locations": {
-      "חניון הרב גרשון וחנה הדס": {
-        "latitude": 31.7474723,
-        "longitude": 35.03383
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_51_report_1_class.html"
-  },
-  {
-    "date": "14/02/2020",
-    "observer": "Iddo_3270859",
-    "title": "רקפת מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חורבת נכס, המכונאי, מודיעין מכבים רעות"
-    ],
-    "flowers": [
-      "רקפת מצויה"
-    ],
-    "geocoded_locations": {
-      "חורבת נכס, המכונאי, מודיעין מכבים רעות": {
-        "latitude": 31.88852799999999,
-        "longitude": 34.957661
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_51_report_1_class.html"
-  },
-  {
-    "date": "14/02/2020",
-    "observer": "Iddo_3270859",
-    "title": "שקד מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חורבת נכס, המכונאי, מודיעין מכבים רעות"
-    ],
-    "flowers": [
-      "שקד מצוי"
-    ],
-    "geocoded_locations": {
-      "חורבת נכס, המכונאי, מודיעין מכבים רעות": {
-        "latitude": 31.88852799999999,
-        "longitude": 34.957661
       }
     },
     "coordinates": [],
@@ -163517,50 +151384,6 @@
       "מערות אפקה, רמת השרון": {
         "latitude": 32.1295375,
         "longitude": 34.8094052
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_51_report_1_class.html"
-  },
-  {
-    "date": "07/02/2020",
-    "observer": "עידו מגן",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שמורת ביתרונות בארי"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "שמורת ביתרונות בארי": {
-        "latitude": 31.4431124,
-        "longitude": 34.4957868
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_51_report_1_class.html"
-  },
-  {
-    "date": "07/02/2020",
-    "observer": "עידו מגן",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער שוקדה, שוקדה"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "יער שוקדה, שוקדה": {
-        "latitude": 31.4267318,
-        "longitude": 34.5124356
       }
     },
     "coordinates": [],
@@ -163996,28 +151819,6 @@
     ],
     "flowers": [
       "נרקיס מצוי"
-    ],
-    "geocoded_locations": {
-      "יער צרעה": {
-        "latitude": 31.7777869,
-        "longitude": 34.9780375
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_51_report_1_class.html"
-  },
-  {
-    "date": "18/01/2020",
-    "observer": "עידו מגן",
-    "title": "רקפת מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער צרעה"
-    ],
-    "flowers": [
-      "רקפת מצויה"
     ],
     "geocoded_locations": {
       "יער צרעה": {
@@ -164644,23 +152445,6 @@
     "source_file": "tiuli_scraped_reports/page_139_report_1_class.html"
   },
   {
-    "date": "14/02/2011",
-    "observer": "המטייל האנונימי",
-    "title": "נרקיס מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "החל דימונה, ליד שכונת נווה חורש בדימונה"
-    ],
-    "flowers": [
-      "נרקיס מצוי"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_139_report_1_class.html"
-  },
-  {
     "date": "12/02/2011",
     "observer": "ymebayer",
     "title": "כלנית מצויה",
@@ -164669,23 +152453,6 @@
     ],
     "locations": [
       "שמורת פורה"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_139_report_1_class.html"
-  },
-  {
-    "date": "12/02/2011",
-    "observer": "ymebayer",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יד מרדכי"
     ],
     "flowers": [
       "כלנית מצויה"
@@ -165393,23 +153160,6 @@
   },
   {
     "date": "19/03/2011",
-    "observer": "Yossy Auerbach",
-    "title": "דבורנית דינסמור",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מול הר ברקן צמוד לכביש לפני הירידה לשביל לעין סמל"
-    ],
-    "flowers": [
-      "דבורנית דינסמור"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_137_report_1_class.html"
-  },
-  {
-    "date": "19/03/2011",
     "observer": "יוחאי כורם",
     "title": "צבעוני המדבר",
     "description": [
@@ -165546,23 +153296,6 @@
   },
   {
     "date": "14/03/2011",
-    "observer": "אלהאושר",
-    "title": "לוטם שעיר",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "ענתות"
-    ],
-    "flowers": [
-      "לוטם שעיר"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_137_report_1_class.html"
-  },
-  {
-    "date": "14/03/2011",
     "observer": "המטייל האנונימי",
     "title": "צבעוני ההרים",
     "description": [
@@ -165664,23 +153397,6 @@
     "source_file": "tiuli_scraped_reports/page_137_report_1_class.html"
   },
   {
-    "date": "08/03/2011",
-    "observer": "המטייל האנונימי",
-    "title": "עיריוני צהוב",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "כביש 6 צפון"
-    ],
-    "flowers": [
-      "עיריוני צהוב"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_137_report_1_class.html"
-  },
-  {
     "date": "07/03/2011",
     "observer": "mrmas",
     "title": "כלנית מצויה",
@@ -165692,23 +153408,6 @@
     ],
     "flowers": [
       "כלנית מצויה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_137_report_1_class.html"
-  },
-  {
-    "date": "06/03/2011",
-    "observer": "המטייל האנונימי",
-    "title": "צבעוני ההרים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שמורת חוף הבונים"
-    ],
-    "flowers": [
-      "צבעוני ההרים"
     ],
     "geocoded_locations": {},
     "coordinates": [],
@@ -166397,23 +154096,6 @@
   {
     "date": "06/02/2009",
     "observer": "המטייל האנונימי",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מנחת מגידו"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_166_report_1_class.html"
-  },
-  {
-    "date": "06/02/2009",
-    "observer": "המטייל האנונימי",
     "title": "רקפת מצויה",
     "description": [
       ""
@@ -166853,50 +154535,6 @@
   {
     "date": "23/11/2018",
     "observer": "עידו מגן",
-    "title": "סתוונית היורה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל יתלה"
-    ],
-    "flowers": [
-      "סתוונית היורה"
-    ],
-    "geocoded_locations": {
-      "נחל יתלה": {
-        "latitude": 31.824022692751683,
-        "longitude": 35.0887618134841
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_56_report_1_class.html"
-  },
-  {
-    "date": "23/11/2018",
-    "observer": "עידו מגן",
-    "title": "נרקיס מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק איילון קנדה"
-    ],
-    "flowers": [
-      "נרקיס מצוי"
-    ],
-    "geocoded_locations": {
-      "פארק איילון קנדה": {
-        "latitude": 31.837722044607563,
-        "longitude": 35.00713060229691
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_56_report_1_class.html"
-  },
-  {
-    "date": "23/11/2018",
-    "observer": "עידו מגן",
     "title": "רקפת מצויה",
     "description": [
       ""
@@ -167043,28 +154681,6 @@
       "נחל שועלים, ירוחם": {
         "latitude": 30.98636569999999,
         "longitude": 34.92381039999998
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_56_report_1_class.html"
-  },
-  {
-    "date": "30/10/2018",
-    "observer": "בת שבע_3637364",
-    "title": "חלמונית גדולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער יתיר"
-    ],
-    "flowers": [
-      "חלמונית גדולה"
-    ],
-    "geocoded_locations": {
-      "יער יתיר": {
-        "latitude": 31.347454,
-        "longitude": 35.03553599999998
       }
     },
     "coordinates": [],
@@ -167403,28 +155019,6 @@
   {
     "date": "10/04/2018",
     "observer": "Michael_3833013",
-    "title": "אירוס הגלבוע",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מלכישוע"
-    ],
-    "flowers": [
-      "אירוס הגלבוע"
-    ],
-    "geocoded_locations": {
-      "מלכישוע": {
-        "latitude": 32.438568,
-        "longitude": 35.412757000000056
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_56_report_1_class.html"
-  },
-  {
-    "date": "10/04/2018",
-    "observer": "Michael_3833013",
     "title": "ברקן סורי",
     "description": [
       ""
@@ -167667,50 +155261,6 @@
   {
     "date": "03/02/2019",
     "observer": "עידו מגן",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער שוקדה, שוקדה"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "יער שוקדה, שוקדה": {
-        "latitude": 31.4267318,
-        "longitude": 34.5124356
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_55_report_1_class.html"
-  },
-  {
-    "date": "03/02/2019",
-    "observer": "עידו מגן",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "אור הנר"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "אור הנר": {
-        "latitude": 31.556197,
-        "longitude": 34.602305
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_55_report_1_class.html"
-  },
-  {
-    "date": "03/02/2019",
-    "observer": "עידו מגן",
     "title": "עירית גדולה",
     "description": [
       ""
@@ -167720,28 +155270,6 @@
     ],
     "flowers": [
       "עירית גדולה"
-    ],
-    "geocoded_locations": {
-      "שמורת רכס גברעם": {
-        "latitude": 31.581564,
-        "longitude": 34.61131
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_55_report_1_class.html"
-  },
-  {
-    "date": "03/02/2019",
-    "observer": "עידו מגן",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שמורת רכס גברעם"
-    ],
-    "flowers": [
-      "כלנית מצויה"
     ],
     "geocoded_locations": {
       "שמורת רכס גברעם": {
@@ -167909,28 +155437,6 @@
   {
     "date": "26/01/2019",
     "observer": "עידו מגן",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "ליפתא, ירושלים"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "ליפתא, ירושלים": {
-        "latitude": 31.7955104011247,
-        "longitude": 35.19545251429827
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_55_report_1_class.html"
-  },
-  {
-    "date": "26/01/2019",
-    "observer": "עידו מגן",
     "title": "עירית גדולה",
     "description": [
       ""
@@ -167962,50 +155468,6 @@
     ],
     "flowers": [
       "רקפת מצויה"
-    ],
-    "geocoded_locations": {
-      "נחל חלילים, מבשרת ציון": {
-        "latitude": 31.8038363,
-        "longitude": 35.156966799999964
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_55_report_1_class.html"
-  },
-  {
-    "date": "26/01/2019",
-    "observer": "עידו מגן",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל חלילים, מבשרת ציון"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "נחל חלילים, מבשרת ציון": {
-        "latitude": 31.8038363,
-        "longitude": 35.156966799999964
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_55_report_1_class.html"
-  },
-  {
-    "date": "26/01/2019",
-    "observer": "עידו מגן",
-    "title": "שקד מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל חלילים, מבשרת ציון"
-    ],
-    "flowers": [
-      "שקד מצוי"
     ],
     "geocoded_locations": {
       "נחל חלילים, מבשרת ציון": {
@@ -168283,28 +155745,6 @@
   {
     "date": "12/01/2019",
     "observer": "mostayel",
-    "title": "נרקיס מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מערות אפקה, רמת השרון"
-    ],
-    "flowers": [
-      "נרקיס מצוי"
-    ],
-    "geocoded_locations": {
-      "מערות אפקה, רמת השרון": {
-        "latitude": 32.1295375,
-        "longitude": 34.809405200000015
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_55_report_1_class.html"
-  },
-  {
-    "date": "12/01/2019",
-    "observer": "mostayel",
     "title": "כליינית מצויה",
     "description": [
       ""
@@ -168371,28 +155811,6 @@
   {
     "date": "05/01/2019",
     "observer": "עידו מגן",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "תל בית שמש, בית שמש"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "תל בית שמש, בית שמש": {
-        "latitude": 31.75030299999999,
-        "longitude": 34.97549500000002
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_55_report_1_class.html"
-  },
-  {
-    "date": "05/01/2019",
-    "observer": "עידו מגן",
     "title": "רקפת מצויה",
     "description": [
       ""
@@ -168402,28 +155820,6 @@
     ],
     "flowers": [
       "רקפת מצויה"
-    ],
-    "geocoded_locations": {
-      "חורבת בורגין, נחושה": {
-        "latitude": 31.63842529999999,
-        "longitude": 34.96964349999996
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_55_report_1_class.html"
-  },
-  {
-    "date": "05/01/2019",
-    "observer": "עידו מגן",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חורבת בורגין, נחושה"
-    ],
-    "flowers": [
-      "כלנית מצויה"
     ],
     "geocoded_locations": {
       "חורבת בורגין, נחושה": {
@@ -168561,28 +155957,6 @@
       "תל חדיד, בן שמן": {
         "latitude": 31.95359999999999,
         "longitude": 34.92098099999998
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_55_report_1_class.html"
-  },
-  {
-    "date": "21/12/2018",
-    "observer": "עידו מגן",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק יער שוהם, שוהם"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "פארק יער שוהם, שוהם": {
-        "latitude": 31.9974478,
-        "longitude": 34.95533599999999
       }
     },
     "coordinates": [],
@@ -168899,28 +156273,6 @@
   {
     "date": "01/07/2020",
     "observer": "אלחי47",
-    "title": "קדד מפורץ",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הר חרמון"
-    ],
-    "flowers": [
-      "קדד מפורץ"
-    ],
-    "geocoded_locations": {
-      "הר חרמון": {
-        "latitude": 802435.0,
-        "longitude": 273429.0
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_46_report_1_class.html"
-  },
-  {
-    "date": "01/07/2020",
-    "observer": "אלחי47",
     "title": "שום עגול",
     "description": [
       ""
@@ -169133,28 +156485,6 @@
       "הר חרמון": {
         "latitude": 802522.0,
         "longitude": 273405.0
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_46_report_1_class.html"
-  },
-  {
-    "date": "30/06/2020",
-    "observer": "אלחי47",
-    "title": "ורד דביק",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הר חרמון"
-    ],
-    "flowers": [
-      "ורד דביק"
-    ],
-    "geocoded_locations": {
-      "הר חרמון": {
-        "latitude": 801495.0,
-        "longitude": 273447.0
       }
     },
     "coordinates": [],
@@ -169507,50 +156837,6 @@
       "כביש 7/כפר נוער כנות": {
         "latitude": 31.808175089671685,
         "longitude": 34.7577551630232
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_46_report_1_class.html"
-  },
-  {
-    "date": "30/05/2020",
-    "observer": "עידו מגן",
-    "title": "חמנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "צומת אשכולות"
-    ],
-    "flowers": [
-      "חמנית מצויה"
-    ],
-    "geocoded_locations": {
-      "צומת אשכולות": {
-        "latitude": 31.72397400000001,
-        "longitude": 34.636261
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_46_report_1_class.html"
-  },
-  {
-    "date": "30/05/2020",
-    "observer": "עידו מגן",
-    "title": "חמנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נגבה"
-    ],
-    "flowers": [
-      "חמנית מצויה"
-    ],
-    "geocoded_locations": {
-      "נגבה": {
-        "latitude": 31.662547,
-        "longitude": 34.67956099999999
       }
     },
     "coordinates": [],
@@ -171450,28 +158736,6 @@
     "source_file": "tiuli_scraped_reports/page_38_report_1_class.html"
   },
   {
-    "date": "08/03/2021",
-    "observer": "EHB",
-    "title": "גזר קיפח",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "גבעת התיתורה, דרך יגאל אלון, מודיעין מכבים רעות"
-    ],
-    "flowers": [
-      "גזר קיפח"
-    ],
-    "geocoded_locations": {
-      "גבעת התיתורה, דרך יגאל אלון, מודיעין מכבים רעות": {
-        "latitude": 31.9027054,
-        "longitude": 35.0176871
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_38_report_1_class.html"
-  },
-  {
     "date": "07/03/2021",
     "observer": "קטיה זובנקו",
     "title": "אירוס נצרתי",
@@ -171561,28 +158825,6 @@
   },
   {
     "date": "07/03/2021",
-    "observer": "Iddo_3270859",
-    "title": "נורית אסיה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חניון נחל קדש"
-    ],
-    "flowers": [
-      "נורית אסיה"
-    ],
-    "geocoded_locations": {
-      "חניון נחל קדש": {
-        "latitude": 33.1184846,
-        "longitude": 35.5676227
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_38_report_1_class.html"
-  },
-  {
-    "date": "07/03/2021",
     "observer": "David_3200024",
     "title": "צבעוני ההרים",
     "description": [
@@ -171598,28 +158840,6 @@
       "חוף הבונים": {
         "latitude": 32.6503462,
         "longitude": 34.9262967
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_38_report_1_class.html"
-  },
-  {
-    "date": "07/03/2021",
-    "observer": "Iddo_3270859",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "טיילת מפגש הנחלים, שדה נחמיה"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "טיילת מפגש הנחלים, שדה נחמיה": {
-        "latitude": 33.1868476,
-        "longitude": 35.6190919
       }
     },
     "coordinates": [],
@@ -172378,28 +159598,6 @@
   {
     "date": "09/08/2011",
     "observer": "גדי פולק",
-    "title": "פטל קדוש",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מחצבת אודים"
-    ],
-    "flowers": [
-      "פטל קדוש"
-    ],
-    "geocoded_locations": {
-      "מחצבת אודים": {
-        "latitude": 32.2575,
-        "longitude": 34.8394
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_130_report_1_class.html"
-  },
-  {
-    "date": "09/08/2011",
-    "observer": "גדי פולק",
     "title": "לשישית מקומטת",
     "description": [
       ""
@@ -172643,23 +159841,6 @@
     ],
     "locations": [
       "צידי הכביש לכפר יהושע"
-    ],
-    "flowers": [
-      "סולנום זיתני"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_130_report_1_class.html"
-  },
-  {
-    "date": "03/07/2011",
-    "observer": "המטייל האנונימי",
-    "title": "סולנום זיתני",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פתח תקוה"
     ],
     "flowers": [
       "סולנום זיתני"
@@ -173268,23 +160449,6 @@
     ],
     "locations": [
       "תל חזיקה  -רכס בשנית"
-    ],
-    "flowers": [
-      "סתוונית התשבץ"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_159_report_1_class.html"
-  },
-  {
-    "date": "01/10/2009",
-    "observer": "המטייל האנונימי",
-    "title": "סתוונית התשבץ",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "רכס חזיקה -בשנית"
     ],
     "flowers": [
       "סתוונית התשבץ"
@@ -174318,28 +161482,6 @@
   {
     "date": "21/06/2012",
     "observer": "גדי פולק",
-    "title": "פטל קדוש",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "עין אלרואי"
-    ],
-    "flowers": [
-      "פטל קדוש"
-    ],
-    "geocoded_locations": {
-      "עין אלרואי": {
-        "latitude": 32.7221,
-        "longitude": 35.1019
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_120_report_1_class.html"
-  },
-  {
-    "date": "21/06/2012",
-    "observer": "גדי פולק",
     "title": "קנה מצוי",
     "description": [
       ""
@@ -174814,23 +161956,6 @@
   {
     "date": "05/03/2008",
     "observer": "המטייל האנונימי",
-    "title": "צהרון מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "גלבוע"
-    ],
-    "flowers": [
-      "צהרון מצוי"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_174_report_1_class.html"
-  },
-  {
-    "date": "05/03/2008",
-    "observer": "המטייל האנונימי",
     "title": "מרווה דגולה",
     "description": [
       ""
@@ -174922,23 +162047,6 @@
     ],
     "locations": [
       "הר מירון"
-    ],
-    "flowers": [
-      "דבורנית שחומה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_174_report_1_class.html"
-  },
-  {
-    "date": "04/03/2008",
-    "observer": "המטייל האנונימי",
-    "title": "דבורנית שחומה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער ביריה"
     ],
     "flowers": [
       "דבורנית שחומה"
@@ -175188,23 +162296,6 @@
   {
     "date": "03/03/2008",
     "observer": "המטייל האנונימי",
-    "title": "סחלב פרפרני",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער חניתה"
-    ],
-    "flowers": [
-      "סחלב פרפרני"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_174_report_1_class.html"
-  },
-  {
-    "date": "03/03/2008",
-    "observer": "המטייל האנונימי",
     "title": "זהבית השלוחות",
     "description": [
       ""
@@ -175271,40 +162362,6 @@
     "source_file": "tiuli_scraped_reports/page_174_report_1_class.html"
   },
   {
-    "date": "02/03/2008",
-    "observer": "המטייל האנונימי",
-    "title": "תורמוס ההרים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "ים המלח"
-    ],
-    "flowers": [
-      "תורמוס ההרים"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_174_report_1_class.html"
-  },
-  {
-    "date": "02/03/2008",
-    "observer": "המטייל האנונימי",
-    "title": "תורמוס ההרים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "צומת אליקים בירידה מכביש 70"
-    ],
-    "flowers": [
-      "תורמוס ההרים"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_174_report_1_class.html"
-  },
-  {
     "date": "01/03/2008",
     "observer": "יוחאי כורם",
     "title": "תורמוס ההרים",
@@ -175363,28 +162420,6 @@
   {
     "date": "17/03/2023",
     "observer": "Iddo_3270859",
-    "title": "סחלב הגליל",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הר יעלה 664"
-    ],
-    "flowers": [
-      "סחלב הגליל"
-    ],
-    "geocoded_locations": {
-      "הר יעלה 664": {
-        "latitude": 31.751376,
-        "longitude": 35.042501
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_15_report_1_class.html"
-  },
-  {
-    "date": "17/03/2023",
-    "observer": "Iddo_3270859",
     "title": "כליל החורש",
     "description": [
       ""
@@ -175399,50 +162434,6 @@
       "3866, נס הרים": {
         "latitude": 31.7471788,
         "longitude": 35.060319
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_15_report_1_class.html"
-  },
-  {
-    "date": "17/03/2023",
-    "observer": "Iddo_3270859",
-    "title": "כליל החורש",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "השפלה"
-    ],
-    "flowers": [
-      "כליל החורש"
-    ],
-    "geocoded_locations": {
-      "השפלה": {
-        "latitude": 31.804305919985676,
-        "longitude": 34.95477341214466
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_15_report_1_class.html"
-  },
-  {
-    "date": "17/03/2023",
-    "observer": "Iddo_3270859",
-    "title": "כליל החורש",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "צלפון"
-    ],
-    "flowers": [
-      "כליל החורש"
-    ],
-    "geocoded_locations": {
-      "צלפון": {
-        "latitude": 31.805599,
-        "longitude": 34.931797
       }
     },
     "coordinates": [],
@@ -175663,28 +162654,6 @@
       "יער נתניה - חורשת הסרג'נטים, נתניה": {
         "latitude": 32.305,
         "longitude": 34.878
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_15_report_1_class.html"
-  },
-  {
-    "date": "17/03/2023",
-    "observer": "אלחי47",
-    "title": "צבעוני ההרים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער נתניה - חורשת הסרג'נטים, נתניה"
-    ],
-    "flowers": [
-      "צבעוני ההרים"
-    ],
-    "geocoded_locations": {
-      "יער נתניה - חורשת הסרג'נטים, נתניה": {
-        "latitude": 32.305,
-        "longitude": 34.879
       }
     },
     "coordinates": [],
@@ -175949,28 +162918,6 @@
       "הר כחל, באזור החרמון": {
         "latitude": 33.28831227260082,
         "longitude": 35.74353320596181
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_15_report_1_class.html"
-  },
-  {
-    "date": "12/03/2023",
-    "observer": "נירה_צ",
-    "title": "יקינתון מזרחי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הר כחל, באזור החרמון"
-    ],
-    "flowers": [
-      "יקינתון מזרחי"
-    ],
-    "geocoded_locations": {
-      "הר כחל, באזור החרמון": {
-        "latitude": 32.88332949474584,
-        "longitude": 35.51105701586913
       }
     },
     "coordinates": [],
@@ -176353,28 +163300,6 @@
   {
     "date": "10/03/2023",
     "observer": "מטייל_4542",
-    "title": "צבעוני ההרים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שמורת אירוס נצרתי, נוף הגליל"
-    ],
-    "flowers": [
-      "צבעוני ההרים"
-    ],
-    "geocoded_locations": {
-      "שמורת אירוס נצרתי, נוף הגליל": {
-        "latitude": 32.71372540184647,
-        "longitude": 35.33933739810975
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_15_report_1_class.html"
-  },
-  {
-    "date": "10/03/2023",
-    "observer": "מטייל_4542",
     "title": "אירוס נצרתי",
     "description": [
       ""
@@ -176567,23 +163492,6 @@
   {
     "date": "11/04/2009",
     "observer": "המטייל האנונימי",
-    "title": "אירוס החרמון",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "צומת המפלים"
-    ],
-    "flowers": [
-      "אירוס החרמון"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_162_report_1_class.html"
-  },
-  {
-    "date": "11/04/2009",
-    "observer": "המטייל האנונימי",
     "title": "אדמונית החורש",
     "description": [
       ""
@@ -176593,23 +163501,6 @@
     ],
     "flowers": [
       "אדמונית החורש"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_162_report_1_class.html"
-  },
-  {
-    "date": "11/04/2009",
-    "observer": "המטייל האנונימי",
-    "title": "אירוס הדור",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "כמון"
-    ],
-    "flowers": [
-      "אירוס הדור"
     ],
     "geocoded_locations": {},
     "coordinates": [],
@@ -176675,23 +163566,6 @@
     ],
     "locations": [
       "נחל נריה"
-    ],
-    "flowers": [
-      "שנק החורש"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_162_report_1_class.html"
-  },
-  {
-    "date": "08/04/2009",
-    "observer": "המטייל האנונימי",
-    "title": "שנק החורש",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער חניתה"
     ],
     "flowers": [
       "שנק החורש"
@@ -179327,28 +166201,6 @@
   {
     "date": "15/02/2014",
     "observer": "גדי פולק",
-    "title": "גרגרנית ערבית",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק סיירת שקד ליד מאגר המים ממערב לכביש"
-    ],
-    "flowers": [
-      "גרגרנית ערבית"
-    ],
-    "geocoded_locations": {
-      "פארק סיירת שקד ליד מאגר המים ממערב לכביש": {
-        "latitude": 31.2711,
-        "longitude": 34.6433
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_95_report_1_class.html"
-  },
-  {
-    "date": "15/02/2014",
-    "observer": "גדי פולק",
     "title": "קזוח עקום",
     "description": [
       ""
@@ -179591,50 +166443,6 @@
   {
     "date": "15/02/2014",
     "observer": "גדי פולק",
-    "title": "גרגרנית ערבית",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק סיירת שקד ליד מאגר המים מזרח לכביש"
-    ],
-    "flowers": [
-      "גרגרנית ערבית"
-    ],
-    "geocoded_locations": {
-      "פארק סיירת שקד ליד מאגר המים מזרח לכביש": {
-        "latitude": 31.2732,
-        "longitude": 34.6453
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_95_report_1_class.html"
-  },
-  {
-    "date": "15/02/2014",
-    "observer": "גדי פולק",
-    "title": "נואית קוצנית",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק סיירת שקד ליד מאגר המים מזרח לכביש"
-    ],
-    "flowers": [
-      "נואית קוצנית"
-    ],
-    "geocoded_locations": {
-      "פארק סיירת שקד ליד מאגר המים מזרח לכביש": {
-        "latitude": 31.2732,
-        "longitude": 34.6453
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_95_report_1_class.html"
-  },
-  {
-    "date": "15/02/2014",
-    "observer": "גדי פולק",
     "title": "תמריר מרוקני",
     "description": [
       ""
@@ -179723,72 +166531,6 @@
   {
     "date": "15/02/2014",
     "observer": "גדי פולק",
-    "title": "מקור-חסידה שעיר",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק סיירת שקד ליד מאגר המים מזרח לכביש"
-    ],
-    "flowers": [
-      "מקור-חסידה שעיר"
-    ],
-    "geocoded_locations": {
-      "פארק סיירת שקד ליד מאגר המים מזרח לכביש": {
-        "latitude": 31.2732,
-        "longitude": 34.6453
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_95_report_1_class.html"
-  },
-  {
-    "date": "15/02/2014",
-    "observer": "גדי פולק",
-    "title": "מתנן שעיר",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק סיירת שקד ליד מאגר המים מזרח לכביש"
-    ],
-    "flowers": [
-      "מתנן שעיר"
-    ],
-    "geocoded_locations": {
-      "פארק סיירת שקד ליד מאגר המים מזרח לכביש": {
-        "latitude": 31.2732,
-        "longitude": 34.6453
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_95_report_1_class.html"
-  },
-  {
-    "date": "15/02/2014",
-    "observer": "גדי פולק",
-    "title": "עירית גדולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק סיירת שקד ליד מאגר המים מזרח לכביש"
-    ],
-    "flowers": [
-      "עירית גדולה"
-    ],
-    "geocoded_locations": {
-      "פארק סיירת שקד ליד מאגר המים מזרח לכביש": {
-        "latitude": 31.2732,
-        "longitude": 34.6453
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_95_report_1_class.html"
-  },
-  {
-    "date": "15/02/2014",
-    "observer": "גדי פולק",
     "title": "צהרון מצוי",
     "description": [
       ""
@@ -179798,28 +166540,6 @@
     ],
     "flowers": [
       "צהרון מצוי"
-    ],
-    "geocoded_locations": {
-      "פארק סיירת שקד ליד מאגר המים מזרח לכביש": {
-        "latitude": 31.2732,
-        "longitude": 34.6453
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_95_report_1_class.html"
-  },
-  {
-    "date": "15/02/2014",
-    "observer": "גדי פולק",
-    "title": "כרוב החוף",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק סיירת שקד ליד מאגר המים מזרח לכביש"
-    ],
-    "flowers": [
-      "כרוב החוף"
     ],
     "geocoded_locations": {
       "פארק סיירת שקד ליד מאגר המים מזרח לכביש": {
@@ -179899,160 +166619,6 @@
   {
     "date": "15/02/2014",
     "observer": "גדי פולק",
-    "title": "מחרוזת משונצת",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק סיירת שקד ליד מאגר המים מזרח לכביש"
-    ],
-    "flowers": [
-      "מחרוזת משונצת"
-    ],
-    "geocoded_locations": {
-      "פארק סיירת שקד ליד מאגר המים מזרח לכביש": {
-        "latitude": 31.2732,
-        "longitude": 34.6453
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_95_report_1_class.html"
-  },
-  {
-    "date": "15/02/2014",
-    "observer": "גדי פולק",
-    "title": "לונאה מחודדת",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק סיירת שקד ליד מאגר המים מזרח לכביש"
-    ],
-    "flowers": [
-      "לונאה מחודדת"
-    ],
-    "geocoded_locations": {
-      "פארק סיירת שקד ליד מאגר המים מזרח לכביש": {
-        "latitude": 31.2732,
-        "longitude": 34.6453
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_95_report_1_class.html"
-  },
-  {
-    "date": "15/02/2014",
-    "observer": "גדי פולק",
-    "title": "מחרוזת משונצת",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק סיירת שקד בפנייה לגשר מסילת הברזל ולאנדרטה"
-    ],
-    "flowers": [
-      "מחרוזת משונצת"
-    ],
-    "geocoded_locations": {
-      "פארק סיירת שקד בפנייה לגשר מסילת הברזל ולאנדרטה": {
-        "latitude": 31.2905,
-        "longitude": 34.6367
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_95_report_1_class.html"
-  },
-  {
-    "date": "15/02/2014",
-    "observer": "גדי פולק",
-    "title": "ציפורני-חתול מצויות",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק סיירת שקד בפנייה לגשר מסילת הברזל ולאנדרטה"
-    ],
-    "flowers": [
-      "ציפורני-חתול מצויות"
-    ],
-    "geocoded_locations": {
-      "פארק סיירת שקד בפנייה לגשר מסילת הברזל ולאנדרטה": {
-        "latitude": 31.2905,
-        "longitude": 34.6367
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_95_report_1_class.html"
-  },
-  {
-    "date": "15/02/2014",
-    "observer": "גדי פולק",
-    "title": "לונאה מחודדת",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק סיירת שקד בפנייה לגשר מסילת הברזל ולאנדרטה"
-    ],
-    "flowers": [
-      "לונאה מחודדת"
-    ],
-    "geocoded_locations": {
-      "פארק סיירת שקד בפנייה לגשר מסילת הברזל ולאנדרטה": {
-        "latitude": 31.2905,
-        "longitude": 34.6367
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_95_report_1_class.html"
-  },
-  {
-    "date": "15/02/2014",
-    "observer": "גדי פולק",
-    "title": "נואית קוצנית",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק סיירת שקד בפנייה לגשר מסילת הברזל ולאנדרטה"
-    ],
-    "flowers": [
-      "נואית קוצנית"
-    ],
-    "geocoded_locations": {
-      "פארק סיירת שקד בפנייה לגשר מסילת הברזל ולאנדרטה": {
-        "latitude": 31.2905,
-        "longitude": 34.6367
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_95_report_1_class.html"
-  },
-  {
-    "date": "15/02/2014",
-    "observer": "גדי פולק",
-    "title": "עירית גדולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק סיירת שקד בפנייה לגשר מסילת הברזל ולאנדרטה"
-    ],
-    "flowers": [
-      "עירית גדולה"
-    ],
-    "geocoded_locations": {
-      "פארק סיירת שקד בפנייה לגשר מסילת הברזל ולאנדרטה": {
-        "latitude": 31.2905,
-        "longitude": 34.6367
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_95_report_1_class.html"
-  },
-  {
-    "date": "15/02/2014",
-    "observer": "גדי פולק",
     "title": "זמזומית איג",
     "description": [
       ""
@@ -180062,28 +166628,6 @@
     ],
     "flowers": [
       "זמזומית איג"
-    ],
-    "geocoded_locations": {
-      "פארק סיירת שקד בפנייה לגשר מסילת הברזל ולאנדרטה": {
-        "latitude": 31.2905,
-        "longitude": 34.6367
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_95_report_1_class.html"
-  },
-  {
-    "date": "15/02/2014",
-    "observer": "גדי פולק",
-    "title": "קיפודן בלאנש",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק סיירת שקד בפנייה לגשר מסילת הברזל ולאנדרטה"
-    ],
-    "flowers": [
-      "קיפודן בלאנש"
     ],
     "geocoded_locations": {
       "פארק סיירת שקד בפנייה לגשר מסילת הברזל ולאנדרטה": {
@@ -180119,28 +166663,6 @@
   {
     "date": "15/02/2014",
     "observer": "גדי פולק",
-    "title": "קזוח עקום",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק סיירת שקד בפנייה לגשר מסילת הברזל ולאנדרטה"
-    ],
-    "flowers": [
-      "קזוח עקום"
-    ],
-    "geocoded_locations": {
-      "פארק סיירת שקד בפנייה לגשר מסילת הברזל ולאנדרטה": {
-        "latitude": 31.2905,
-        "longitude": 34.6367
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_95_report_1_class.html"
-  },
-  {
-    "date": "15/02/2014",
-    "observer": "גדי פולק",
     "title": "נץ-חלב דק-עלים",
     "description": [
       ""
@@ -180150,72 +166672,6 @@
     ],
     "flowers": [
       "נץ-חלב דק-עלים"
-    ],
-    "geocoded_locations": {
-      "פארק סיירת שקד בפנייה לגשר מסילת הברזל ולאנדרטה": {
-        "latitude": 31.2905,
-        "longitude": 34.6367
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_95_report_1_class.html"
-  },
-  {
-    "date": "15/02/2014",
-    "observer": "גדי פולק",
-    "title": "מתנן שעיר",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק סיירת שקד בפנייה לגשר מסילת הברזל ולאנדרטה"
-    ],
-    "flowers": [
-      "מתנן שעיר"
-    ],
-    "geocoded_locations": {
-      "פארק סיירת שקד בפנייה לגשר מסילת הברזל ולאנדרטה": {
-        "latitude": 31.2905,
-        "longitude": 34.6367
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_95_report_1_class.html"
-  },
-  {
-    "date": "15/02/2014",
-    "observer": "גדי פולק",
-    "title": "צהרון מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק סיירת שקד בפנייה לגשר מסילת הברזל ולאנדרטה"
-    ],
-    "flowers": [
-      "צהרון מצוי"
-    ],
-    "geocoded_locations": {
-      "פארק סיירת שקד בפנייה לגשר מסילת הברזל ולאנדרטה": {
-        "latitude": 31.2905,
-        "longitude": 34.6367
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_95_report_1_class.html"
-  },
-  {
-    "date": "15/02/2014",
-    "observer": "גדי פולק",
-    "title": "גרגרנית ערבית",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק סיירת שקד בפנייה לגשר מסילת הברזל ולאנדרטה"
-    ],
-    "flowers": [
-      "גרגרנית ערבית"
     ],
     "geocoded_locations": {
       "פארק סיירת שקד בפנייה לגשר מסילת הברזל ולאנדרטה": {
@@ -181057,28 +167513,6 @@
       "החרמון": {
         "latitude": 33.3069,
         "longitude": 35.7853
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_69_report_1_class.html"
-  },
-  {
-    "date": "07/05/2016",
-    "observer": "אלחי47",
-    "title": "פרגה קרחת",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "החרמון"
-    ],
-    "flowers": [
-      "פרגה קרחת"
-    ],
-    "geocoded_locations": {
-      "החרמון": {
-        "latitude": 33.3056,
-        "longitude": 35.7823
       }
     },
     "coordinates": [],
@@ -182527,28 +168961,6 @@
     "source_file": "tiuli_scraped_reports/page_23_report_1_class.html"
   },
   {
-    "date": "26/09/2022",
-    "observer": "Iddo_3270859",
-    "title": "חצב מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "גן לאומי אפולוניה, הרצליה"
-    ],
-    "flowers": [
-      "חצב מצוי"
-    ],
-    "geocoded_locations": {
-      "גן לאומי אפולוניה, הרצליה": {
-        "latitude": 32.194219,
-        "longitude": 34.80790700000001
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_23_report_1_class.html"
-  },
-  {
     "date": "10/09/2022",
     "observer": "Iddo_3270859",
     "title": "חצב מצוי",
@@ -182813,28 +169225,6 @@
     "source_file": "tiuli_scraped_reports/page_23_report_1_class.html"
   },
   {
-    "date": "01/07/2022",
-    "observer": "אלחי47",
-    "title": "כף-אווז לבנה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הר חרמון"
-    ],
-    "flowers": [
-      "כף-אווז לבנה"
-    ],
-    "geocoded_locations": {
-      "הר חרמון": {
-        "latitude": 33.30798980000001,
-        "longitude": 35.7726723
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_23_report_1_class.html"
-  },
-  {
     "date": "30/06/2022",
     "observer": "אלחי47",
     "title": "לוענית מצויה",
@@ -183070,28 +169460,6 @@
     "geocoded_locations": {
       "גן לאומי תל אפק, תל אפק": {
         "latitude": 32.10530919999999,
-        "longitude": 35.112
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_23_report_1_class.html"
-  },
-  {
-    "date": "22/06/2022",
-    "observer": "אלחי47",
-    "title": "נימפאה תכולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "גן לאומי תל אפק, תל אפק"
-    ],
-    "flowers": [
-      "נימפאה תכולה"
-    ],
-    "geocoded_locations": {
-      "גן לאומי תל אפק, תל אפק": {
-        "latitude": 332.10530919999997,
         "longitude": 35.112
       }
     },
@@ -183405,28 +169773,6 @@
     },
     "coordinates": [],
     "source_file": "tiuli_scraped_reports/page_23_report_1_class.html"
-  },
-  {
-    "date": "15/06/2015",
-    "observer": "יוחאי כורם",
-    "title": "אלמוות הכסף",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "קיסריה"
-    ],
-    "flowers": [
-      "אלמוות הכסף"
-    ],
-    "geocoded_locations": {
-      "קיסריה": {
-        "latitude": 32.5,
-        "longitude": 34.8
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_74_report_1_class.html"
   },
   {
     "date": "15/06/2015",
@@ -184839,28 +171185,6 @@
   {
     "date": "06/01/2023",
     "observer": "Iddo_3270859",
-    "title": "רקפת מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שמורת אודים, אודים"
-    ],
-    "flowers": [
-      "רקפת מצויה"
-    ],
-    "geocoded_locations": {
-      "שמורת אודים, אודים": {
-        "latitude": 32.26059550000001,
-        "longitude": 34.8398234
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_21_report_1_class.html"
-  },
-  {
-    "date": "06/01/2023",
-    "observer": "Iddo_3270859",
     "title": "כלנית מצויה",
     "description": [
       ""
@@ -185007,28 +171331,6 @@
       "שמורת הנרקיסים ביתן אהרון.": {
         "latitude": 32.364,
         "longitude": 34.865
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_21_report_1_class.html"
-  },
-  {
-    "date": "02/01/2023",
-    "observer": "אלחי47",
-    "title": "אסתר מרצעני",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "ביתן אהרוןף"
-    ],
-    "flowers": [
-      "אסתר מרצעני"
-    ],
-    "geocoded_locations": {
-      "ביתן אהרוןף": {
-        "latitude": 32.164,
-        "longitude": 34.867
       }
     },
     "coordinates": [],
@@ -186105,50 +172407,6 @@
   {
     "date": "31/01/2012",
     "observer": "גדי פולק",
-    "title": "טוריים מצויים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "צומת סעד"
-    ],
-    "flowers": [
-      "טוריים מצויים"
-    ],
-    "geocoded_locations": {
-      "צומת סעד": {
-        "latitude": 31.4682,
-        "longitude": 34.5292
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_124_report_1_class.html"
-  },
-  {
-    "date": "31/01/2012",
-    "observer": "גדי פולק",
-    "title": "ציפורני-חתול מצויות",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "צומת סעד"
-    ],
-    "flowers": [
-      "ציפורני-חתול מצויות"
-    ],
-    "geocoded_locations": {
-      "צומת סעד": {
-        "latitude": 31.4682,
-        "longitude": 34.5292
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_124_report_1_class.html"
-  },
-  {
-    "date": "31/01/2012",
-    "observer": "גדי פולק",
     "title": "כתמה עבת-שורשים",
     "description": [
       ""
@@ -186180,28 +172438,6 @@
     ],
     "flowers": [
       "מקור-חסידה חלמיתי"
-    ],
-    "geocoded_locations": {
-      "צומת סעד": {
-        "latitude": 31.4682,
-        "longitude": 34.5292
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_124_report_1_class.html"
-  },
-  {
-    "date": "31/01/2012",
-    "observer": "גדי פולק",
-    "title": "נונאה פלשתית",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "צומת סעד"
-    ],
-    "flowers": [
-      "נונאה פלשתית"
     ],
     "geocoded_locations": {
       "צומת סעד": {
@@ -186325,116 +172561,6 @@
   {
     "date": "31/01/2012",
     "observer": "גדי פולק",
-    "title": "כלנית מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער שוקדה"
-    ],
-    "flowers": [
-      "כלנית מצויה"
-    ],
-    "geocoded_locations": {
-      "יער שוקדה": {
-        "latitude": 31.4279,
-        "longitude": 34.5235
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_124_report_1_class.html"
-  },
-  {
-    "date": "31/01/2012",
-    "observer": "גדי פולק",
-    "title": "ניסנית דו-קרנית",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער שוקדה"
-    ],
-    "flowers": [
-      "ניסנית דו-קרנית"
-    ],
-    "geocoded_locations": {
-      "יער שוקדה": {
-        "latitude": 31.4279,
-        "longitude": 34.5235
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_124_report_1_class.html"
-  },
-  {
-    "date": "31/01/2012",
-    "observer": "גדי פולק",
-    "title": "ציפורני-חתול מצויות",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער שוקדה"
-    ],
-    "flowers": [
-      "ציפורני-חתול מצויות"
-    ],
-    "geocoded_locations": {
-      "יער שוקדה": {
-        "latitude": 31.4279,
-        "longitude": 34.5235
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_124_report_1_class.html"
-  },
-  {
-    "date": "31/01/2012",
-    "observer": "גדי פולק",
-    "title": "כתמה עבת-שורשים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער שוקדה"
-    ],
-    "flowers": [
-      "כתמה עבת-שורשים"
-    ],
-    "geocoded_locations": {
-      "יער שוקדה": {
-        "latitude": 31.4279,
-        "longitude": 34.5235
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_124_report_1_class.html"
-  },
-  {
-    "date": "31/01/2012",
-    "observer": "גדי פולק",
-    "title": "טוריים מצויים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער שוקדה"
-    ],
-    "flowers": [
-      "טוריים מצויים"
-    ],
-    "geocoded_locations": {
-      "יער שוקדה": {
-        "latitude": 31.4279,
-        "longitude": 34.5235
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_124_report_1_class.html"
-  },
-  {
-    "date": "31/01/2012",
-    "observer": "גדי פולק",
     "title": "אירוס ארץ-ישראלי",
     "description": [
       ""
@@ -186444,50 +172570,6 @@
     ],
     "flowers": [
       "אירוס ארץ-ישראלי"
-    ],
-    "geocoded_locations": {
-      "יער שוקדה": {
-        "latitude": 31.4279,
-        "longitude": 34.5235
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_124_report_1_class.html"
-  },
-  {
-    "date": "31/01/2012",
-    "observer": "גדי פולק",
-    "title": "נונאה פלשתית",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער שוקדה"
-    ],
-    "flowers": [
-      "נונאה פלשתית"
-    ],
-    "geocoded_locations": {
-      "יער שוקדה": {
-        "latitude": 31.4279,
-        "longitude": 34.5235
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_124_report_1_class.html"
-  },
-  {
-    "date": "31/01/2012",
-    "observer": "גדי פולק",
-    "title": "מקור-חסידה חלמיתי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער שוקדה"
-    ],
-    "flowers": [
-      "מקור-חסידה חלמיתי"
     ],
     "geocoded_locations": {
       "יער שוקדה": {
@@ -186611,28 +172693,6 @@
   {
     "date": "08/12/2020",
     "observer": "שיר בהר",
-    "title": "רקפת מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חורבת חנות"
-    ],
-    "flowers": [
-      "רקפת מצויה"
-    ],
-    "geocoded_locations": {
-      "חורבת חנות": {
-        "latitude": 31.7116546,
-        "longitude": 35.04688640000001
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_44_report_1_class.html"
-  },
-  {
-    "date": "08/12/2020",
-    "observer": "שיר בהר",
     "title": "נרקיס סתווי",
     "description": [
       ""
@@ -186647,28 +172707,6 @@
       "מעגן מיכאל": {
         "latitude": 32.55871,
         "longitude": 34.917816
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_44_report_1_class.html"
-  },
-  {
-    "date": "08/12/2020",
-    "observer": "שיר בהר",
-    "title": "אירוס הסרגל",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "דרך נוף כרמל, עיספיא"
-    ],
-    "flowers": [
-      "אירוס הסרגל"
-    ],
-    "geocoded_locations": {
-      "דרך נוף כרמל, עיספיא": {
-        "latitude": 32.74981999999999,
-        "longitude": 35.0533729
       }
     },
     "coordinates": [],
@@ -186721,50 +172759,6 @@
   {
     "date": "08/12/2020",
     "observer": "שיר בהר",
-    "title": "אירוס הסרגל",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "קרן הכרמל"
-    ],
-    "flowers": [
-      "אירוס הסרגל"
-    ],
-    "geocoded_locations": {
-      "קרן הכרמל": {
-        "latitude": 32.672778,
-        "longitude": 35.088611
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_44_report_1_class.html"
-  },
-  {
-    "date": "08/12/2020",
-    "observer": "שיר בהר",
-    "title": "רקפת מצויה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חורבת חנות"
-    ],
-    "flowers": [
-      "רקפת מצויה"
-    ],
-    "geocoded_locations": {
-      "חורבת חנות": {
-        "latitude": 31.7116546,
-        "longitude": 35.04688640000001
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_44_report_1_class.html"
-  },
-  {
-    "date": "08/12/2020",
-    "observer": "שיר בהר",
     "title": "ציפורן נקוד",
     "description": [
       ""
@@ -186779,28 +172773,6 @@
       "שמורת אודים, אודים": {
         "latitude": 32.26059550000001,
         "longitude": 34.8398234
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_44_report_1_class.html"
-  },
-  {
-    "date": "08/12/2020",
-    "observer": "שיר בהר",
-    "title": "חיננית הבתה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער קולה"
-    ],
-    "flowers": [
-      "חיננית הבתה"
-    ],
-    "geocoded_locations": {
-      "יער קולה": {
-        "latitude": 32.0416692,
-        "longitude": 34.9589393
       }
     },
     "coordinates": [],
@@ -186911,28 +172883,6 @@
       "עמק הארזים, ירושלים": {
         "latitude": 31.809699298081977,
         "longitude": 35.18540920355469
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_44_report_1_class.html"
-  },
-  {
-    "date": "04/12/2020",
-    "observer": "עידו מגן",
-    "title": "כרכום חורפי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חורבת חנות"
-    ],
-    "flowers": [
-      "כרכום חורפי"
-    ],
-    "geocoded_locations": {
-      "חורבת חנות": {
-        "latitude": 31.7116546,
-        "longitude": 35.04688640000001
       }
     },
     "coordinates": [],
@@ -187117,28 +173067,6 @@
   {
     "date": "29/11/2020",
     "observer": "שיר בהר",
-    "title": "נרקיס מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "יער חורשים"
-    ],
-    "flowers": [
-      "נרקיס מצוי"
-    ],
-    "geocoded_locations": {
-      "יער חורשים": {
-        "latitude": 32.14500799999999,
-        "longitude": 34.971757
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_44_report_1_class.html"
-  },
-  {
-    "date": "29/11/2020",
-    "observer": "שיר בהר",
     "title": "סתוונית היורה",
     "description": [
       ""
@@ -187161,72 +173089,6 @@
   {
     "date": "29/11/2020",
     "observer": "שיר בהר",
-    "title": "נרקיס מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חוף ראש הנקרה, מנהרות הרכבת בראש הנקרה"
-    ],
-    "flowers": [
-      "נרקיס מצוי"
-    ],
-    "geocoded_locations": {
-      "חוף ראש הנקרה, מנהרות הרכבת בראש הנקרה": {
-        "latitude": 33.093162,
-        "longitude": 35.1042121
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_44_report_1_class.html"
-  },
-  {
-    "date": "29/11/2020",
-    "observer": "שיר בהר",
-    "title": "נרקיס מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "חי בר כרמל, חיפה"
-    ],
-    "flowers": [
-      "נרקיס מצוי"
-    ],
-    "geocoded_locations": {
-      "חי בר כרמל, חיפה": {
-        "latitude": 32.75433,
-        "longitude": 35.016823
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_44_report_1_class.html"
-  },
-  {
-    "date": "29/11/2020",
-    "observer": "שיר בהר",
-    "title": "נרקיס מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "\"שוויצריה הקטנה\""
-    ],
-    "flowers": [
-      "נרקיס מצוי"
-    ],
-    "geocoded_locations": {
-      "\"שוויצריה הקטנה\"": {
-        "latitude": 32.7456038,
-        "longitude": 35.0254741
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_44_report_1_class.html"
-  },
-  {
-    "date": "29/11/2020",
-    "observer": "שיר בהר",
     "title": "בן-חצב סתווני",
     "description": [
       ""
@@ -187236,50 +173098,6 @@
     ],
     "flowers": [
       "בן-חצב סתווני"
-    ],
-    "geocoded_locations": {
-      "פארק יער שהם, שוהם": {
-        "latitude": 31.9974478,
-        "longitude": 34.955336
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_44_report_1_class.html"
-  },
-  {
-    "date": "29/11/2020",
-    "observer": "שיר בהר",
-    "title": "סתוונית היורה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק יער שהם, שוהם"
-    ],
-    "flowers": [
-      "סתוונית היורה"
-    ],
-    "geocoded_locations": {
-      "פארק יער שהם, שוהם": {
-        "latitude": 31.9974478,
-        "longitude": 34.955336
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_44_report_1_class.html"
-  },
-  {
-    "date": "29/11/2020",
-    "observer": "שיר בהר",
-    "title": "נרקיס מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק יער שהם, שוהם"
-    ],
-    "flowers": [
-      "נרקיס מצוי"
     ],
     "geocoded_locations": {
       "פארק יער שהם, שוהם": {
@@ -187491,28 +173309,6 @@
   {
     "date": "22/11/2020",
     "observer": "שיר בהר",
-    "title": "כרכום חורפי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "בן שמן"
-    ],
-    "flowers": [
-      "כרכום חורפי"
-    ],
-    "geocoded_locations": {
-      "בן שמן": {
-        "latitude": 31.953601,
-        "longitude": 34.92098
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_44_report_1_class.html"
-  },
-  {
-    "date": "22/11/2020",
-    "observer": "שיר בהר",
     "title": "כרכום השבכה",
     "description": [
       ""
@@ -187522,28 +173318,6 @@
     ],
     "flowers": [
       "כרכום השבכה"
-    ],
-    "geocoded_locations": {
-      "שביל הפסגה": {
-        "latitude": 32.993795,
-        "longitude": 35.41427300000001
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_44_report_1_class.html"
-  },
-  {
-    "date": "22/11/2020",
-    "observer": "שיר בהר",
-    "title": "כרכום חורפי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "שביל הפסגה"
-    ],
-    "flowers": [
-      "כרכום חורפי"
     ],
     "geocoded_locations": {
       "שביל הפסגה": {
@@ -187723,23 +173497,6 @@
     "source_file": "tiuli_scraped_reports/page_169_report_1_class.html"
   },
   {
-    "date": "16/11/2008",
-    "observer": "המטייל האנונימי",
-    "title": "נרקיס מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל עמוד/מירון"
-    ],
-    "flowers": [
-      "נרקיס מצוי"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_169_report_1_class.html"
-  },
-  {
     "date": "15/11/2008",
     "observer": "המטייל האנונימי",
     "title": "גלדן סמרני",
@@ -187810,23 +173567,6 @@
   {
     "date": "15/11/2008",
     "observer": "המטייל האנונימי",
-    "title": "נרקיס מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל הוד"
-    ],
-    "flowers": [
-      "נרקיס מצוי"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_169_report_1_class.html"
-  },
-  {
-    "date": "15/11/2008",
-    "observer": "המטייל האנונימי",
     "title": "רקפת מצויה",
     "description": [
       ""
@@ -187867,23 +173607,6 @@
     ],
     "locations": [
       "מערות לוזית"
-    ],
-    "flowers": [
-      "סתוונית היורה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_169_report_1_class.html"
-  },
-  {
-    "date": "14/11/2008",
-    "observer": "המטייל האנונימי",
-    "title": "סתוונית היורה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "גבעות מע'אר ליד גדרה"
     ],
     "flowers": [
       "סתוונית היורה"
@@ -188099,23 +173822,6 @@
   {
     "date": "08/11/2008",
     "observer": "המטייל האנונימי",
-    "title": "חלמונית גדולה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "מצוקי האון ליד מבוא חמה"
-    ],
-    "flowers": [
-      "חלמונית גדולה"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_169_report_1_class.html"
-  },
-  {
-    "date": "08/11/2008",
-    "observer": "המטייל האנונימי",
     "title": "רקפת מצויה",
     "description": [
       ""
@@ -188142,23 +173848,6 @@
     ],
     "flowers": [
       "בן-חצב סתווני"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_169_report_1_class.html"
-  },
-  {
-    "date": "08/11/2008",
-    "observer": "המטייל האנונימי",
-    "title": "סתוונית היורה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "גבעת החאן"
-    ],
-    "flowers": [
-      "סתוונית היורה"
     ],
     "geocoded_locations": {},
     "coordinates": [],
@@ -188207,23 +173896,6 @@
     ],
     "locations": [
       "מושב לימן"
-    ],
-    "flowers": [
-      "כדן קטן-פרחים"
-    ],
-    "geocoded_locations": {},
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_169_report_1_class.html"
-  },
-  {
-    "date": "06/11/2008",
-    "observer": "המטייל האנונימי",
-    "title": "כדן קטן-פרחים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק אדמית"
     ],
     "flowers": [
       "כדן קטן-פרחים"
@@ -188475,28 +174147,6 @@
       "עיינות": {
         "latitude": 31.906225533595382,
         "longitude": 34.76231725653983
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_13_report_1_class.html"
-  },
-  {
-    "date": "11/04/2023",
-    "observer": "Iddo_3270859",
-    "title": "בקיה דקת-עלים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "פארק הדייג דג וגן, דרך השדות, בית חנן"
-    ],
-    "flowers": [
-      "בקיה דקת-עלים"
-    ],
-    "geocoded_locations": {
-      "פארק הדייג דג וגן, דרך השדות, בית חנן": {
-        "latitude": 31.9194903,
-        "longitude": 34.7646208
       }
     },
     "coordinates": [],
@@ -188783,28 +174433,6 @@
       "נחל דישון": {
         "latitude": 33.03900852005074,
         "longitude": 35.43415199997968
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_13_report_1_class.html"
-  },
-  {
-    "date": "08/04/2023",
-    "observer": "Iddo_3270859",
-    "title": "סחלב איטלקי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "הר פועה"
-    ],
-    "flowers": [
-      "סחלב איטלקי"
-    ],
-    "geocoded_locations": {
-      "הר פועה": {
-        "latitude": 33.050403222960036,
-        "longitude": 35.46062846099662
       }
     },
     "coordinates": [],
@@ -189935,28 +175563,6 @@
   {
     "date": "05/03/2013",
     "observer": "גדי פולק",
-    "title": "מלעניאל מצוי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל נקרות ליד גשר כביש 40"
-    ],
-    "flowers": [
-      "מלעניאל מצוי"
-    ],
-    "geocoded_locations": {
-      "נחל נקרות ליד גשר כביש 40": {
-        "latitude": 30.5659,
-        "longitude": 34.9025
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_111_report_1_class.html"
-  },
-  {
-    "date": "05/03/2013",
-    "observer": "גדי פולק",
     "title": "פגוניה ערבית",
     "description": [
       ""
@@ -190111,28 +175717,6 @@
   {
     "date": "05/03/2013",
     "observer": "גדי פולק",
-    "title": "רותם המדבר",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל נקרות ליד גשר כביש 40"
-    ],
-    "flowers": [
-      "רותם המדבר"
-    ],
-    "geocoded_locations": {
-      "נחל נקרות ליד גשר כביש 40": {
-        "latitude": 30.5659,
-        "longitude": 34.9025
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_111_report_1_class.html"
-  },
-  {
-    "date": "05/03/2013",
-    "observer": "גדי פולק",
     "title": "סילון קוצני",
     "description": [
       ""
@@ -190147,204 +175731,6 @@
       "נחל נקרות ליד גשר כביש 40": {
         "latitude": 30.5659,
         "longitude": 34.9025
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_111_report_1_class.html"
-  },
-  {
-    "date": "05/03/2013",
-    "observer": "גדי פולק",
-    "title": "סילון קוצני",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל פארן חציית כביש 40"
-    ],
-    "flowers": [
-      "סילון קוצני"
-    ],
-    "geocoded_locations": {
-      "נחל פארן חציית כביש 40": {
-        "latitude": 30.3242,
-        "longitude": 34.9547
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_111_report_1_class.html"
-  },
-  {
-    "date": "05/03/2013",
-    "observer": "גדי פולק",
-    "title": "טוריים מדבריים",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל פארן חציית כביש 40"
-    ],
-    "flowers": [
-      "טוריים מדבריים"
-    ],
-    "geocoded_locations": {
-      "נחל פארן חציית כביש 40": {
-        "latitude": 30.3242,
-        "longitude": 34.9547
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_111_report_1_class.html"
-  },
-  {
-    "date": "05/03/2013",
-    "observer": "גדי פולק",
-    "title": "מוריקה מבריקה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל פארן חציית כביש 40"
-    ],
-    "flowers": [
-      "מוריקה מבריקה"
-    ],
-    "geocoded_locations": {
-      "נחל פארן חציית כביש 40": {
-        "latitude": 30.3242,
-        "longitude": 34.9547
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_111_report_1_class.html"
-  },
-  {
-    "date": "05/03/2013",
-    "observer": "גדי פולק",
-    "title": "שיכרון מדברי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל פארן חציית כביש 40"
-    ],
-    "flowers": [
-      "שיכרון מדברי"
-    ],
-    "geocoded_locations": {
-      "נחל פארן חציית כביש 40": {
-        "latitude": 30.3242,
-        "longitude": 34.9547
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_111_report_1_class.html"
-  },
-  {
-    "date": "05/03/2013",
-    "observer": "גדי פולק",
-    "title": "פגוניה רכה",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל פארן חציית כביש 40"
-    ],
-    "flowers": [
-      "פגוניה רכה"
-    ],
-    "geocoded_locations": {
-      "נחל פארן חציית כביש 40": {
-        "latitude": 30.3242,
-        "longitude": 34.9547
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_111_report_1_class.html"
-  },
-  {
-    "date": "05/03/2013",
-    "observer": "גדי פולק",
-    "title": "לוטוס מדברי",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל פארן חציית כביש 40"
-    ],
-    "flowers": [
-      "לוטוס מדברי"
-    ],
-    "geocoded_locations": {
-      "נחל פארן חציית כביש 40": {
-        "latitude": 30.3242,
-        "longitude": 34.9547
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_111_report_1_class.html"
-  },
-  {
-    "date": "05/03/2013",
-    "observer": "גדי פולק",
-    "title": "אמיך קוצני",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל פארן חציית כביש 40"
-    ],
-    "flowers": [
-      "אמיך קוצני"
-    ],
-    "geocoded_locations": {
-      "נחל פארן חציית כביש 40": {
-        "latitude": 30.3242,
-        "longitude": 34.9547
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_111_report_1_class.html"
-  },
-  {
-    "date": "05/03/2013",
-    "observer": "גדי פולק",
-    "title": "כוכב ריחני",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל פארן חציית כביש 40"
-    ],
-    "flowers": [
-      "כוכב ריחני"
-    ],
-    "geocoded_locations": {
-      "נחל פארן חציית כביש 40": {
-        "latitude": 30.3242,
-        "longitude": 34.9547
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_111_report_1_class.html"
-  },
-  {
-    "date": "05/03/2013",
-    "observer": "גדי פולק",
-    "title": "דרדר המדבר",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל פארן חציית כביש 40"
-    ],
-    "flowers": [
-      "דרדר המדבר"
-    ],
-    "geocoded_locations": {
-      "נחל פארן חציית כביש 40": {
-        "latitude": 30.3242,
-        "longitude": 34.9547
       }
     },
     "coordinates": [],
@@ -190362,28 +175748,6 @@
     ],
     "flowers": [
       "צלף מצרי"
-    ],
-    "geocoded_locations": {
-      "נחל פארן חציית כביש 40": {
-        "latitude": 30.3242,
-        "longitude": 34.9547
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_111_report_1_class.html"
-  },
-  {
-    "date": "05/03/2013",
-    "observer": "גדי פולק",
-    "title": "פגוניה ערבית",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל פארן חציית כביש 40"
-    ],
-    "flowers": [
-      "פגוניה ערבית"
     ],
     "geocoded_locations": {
       "נחל פארן חציית כביש 40": {
@@ -190428,28 +175792,6 @@
     ],
     "flowers": [
       "קדד משולחף"
-    ],
-    "geocoded_locations": {
-      "נחל פארן חציית כביש 40": {
-        "latitude": 30.3242,
-        "longitude": 34.9547
-      }
-    },
-    "coordinates": [],
-    "source_file": "tiuli_scraped_reports/page_111_report_1_class.html"
-  },
-  {
-    "date": "05/03/2013",
-    "observer": "גדי פולק",
-    "title": "תמריר מרוקני",
-    "description": [
-      ""
-    ],
-    "locations": [
-      "נחל פארן חציית כביש 40"
-    ],
-    "flowers": [
-      "תמריר מרוקני"
     ],
     "geocoded_locations": {
       "נחל פארן חציית כביש 40": {


### PR DESCRIPTION
Corrects the composite key lookup and element selection hierarchy in `pipeline.py`'s `process_tiuli_files` to ensure existing reports are properly detected and skipped, preventing infinite duplication loops. Also cleans up the existing duplicate records in `wildflowers_data.json` and adds dedicated test coverage.

---
*PR created automatically by Jules for task [13426736134780022118](https://jules.google.com/task/13426736134780022118) started by @baobabprince*